### PR TITLE
add missing media/uploads due to incorrect .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 .vscode
 npm-debug.log
 node_modules
-media/uploads
+media/uploads/*
 !media/uploads/3d5c935c.xml

--- a/media/uploads/3d5c935c.xml
+++ b/media/uploads/3d5c935c.xml
@@ -1,0 +1,9 @@
+<logical-query>
+    <selects>
+        <field>H</field>
+        <field>E</field>
+        <field>L</field>
+        <field>L</field>
+        <field>O</field>
+    </selects>
+</logical-query>


### PR DESCRIPTION
The media/uploads directory was lost in move to GitHub due to incorrect ignore entry.

A file or text upload using upload-server.js will fail with ENOENT without media/uploads.

Thanks to Franz Amador for finding. 