### PR TITLE
Refactoring: cleaner interface between loaders and graph rendering

### DIFF
--- a/d3/colors.js
+++ b/d3/colors.js
@@ -8,13 +8,13 @@ var colorFederated = function(treeData) {
         if (d.tag && d.tag === 'fed-op') {
             if (d.properties && d.properties.connection) {
                 d.federated = d.properties.connection.split(".")[0];
+                d.nodeClass = d.properties.connection.split(".")[0];
             }
         } else if (d.parent && d.parent.federated) {
             d.federated = d.parent.federated;
+            d.nodeClass = d.parent.federated;
         }
-    }, function(d) {
-        return d.children && d.children.length > 0 ? d.children : null;
-    });
+    }, common.allChildren);
 };
 
 exports.colorFederated = colorFederated;

--- a/d3/common.js
+++ b/d3/common.js
@@ -50,9 +50,8 @@ function collapseChildren(d) {
     return d;
 }
 
-// Collapse all but me in my parent node
+// Collapse the given node in its parent node
 // Requires parent links to be present (e.g., created by `createParentLinks`)
-// Nodes may have children and _children that were children prior to streamline
 function streamline(d) {
     if (d.parent) {
         if (d.parent._children && d.parent._children !== null && d.parent._children.length > 0) {

--- a/d3/common.js
+++ b/d3/common.js
@@ -23,5 +23,50 @@ function allChildren(n) {
     return _childrenLength > childrenLength ? n._children : n.children;
 }
 
+// Create parent links
+function createParentLinks(tree) {
+    visit(tree, function() {}, function(d) {
+        if (d.children) {
+            var children = allChildren(d);
+            var count = children.length;
+            for (var i = 0; i < count; i++) {
+                children[i].parent = d;
+            }
+            return children;
+        }
+        return null;
+    });
+}
+
+// Collapse all children regardless of the current state
+function collapseChildren(d) {
+    var children = (d.children) ? d.children : null;
+    var _children = (d._children) ? d._children : null;
+    // all original children are in _children or none are
+    if (_children === null || _children.length === 0) {
+        d._children = children;
+    }
+    d.children = null;
+    return d;
+}
+
+// Collapse all but me in my parent node
+// Requires parent links to be present (e.g., created by `createParentLinks`)
+// Nodes may have children and _children that were children prior to streamline
+function streamline(d) {
+    if (d.parent) {
+        if (d.parent._children && d.parent._children !== null && d.parent._children.length > 0) {
+            // save all of the original children in _chidren one time only
+        } else {
+            d.parent._children = d.parent.children.slice(0);
+        }
+        var index = d.parent.children.indexOf(d);
+        d.parent.children.splice(index, 1);
+    }
+}
+
 exports.visit = visit;
 exports.allChildren = allChildren;
+exports.createParentLinks = createParentLinks;
+exports.collapseChildren = collapseChildren;
+exports.streamline = streamline;

--- a/d3/hyper.js
+++ b/d3/hyper.js
@@ -60,7 +60,7 @@ function convertHyper(node, tag) {
                 case "count":
                 case "from":
                 case "id":
-                case "matchMode":
+                case "matchMode": // legacy; used by the university Hyper instead of `singleMatch`
                 case "operatorId":
                 case "method":
                 case "segment":
@@ -301,67 +301,32 @@ function collapseNodes(treeData, graphCollapse) {
     var collapseChildren = common.collapseChildren;
     if (graphCollapse !== 'n') {
         common.visit(treeData, function(d) {
-            if (d.name) {
-                var _name = d.fullName ? d.fullName : d.name;
-                switch (_name) {
-                    case 'aggregates':
-                    case 'builder':
-                    case 'cardinality':
-                    case 'condition':
-                    case 'conditions':
-                    case 'count':
-                    case 'criterion':
-                    case 'datasource':
-                    case 'expressions':
-                    case 'field':
-                    case 'from':
-                    case 'groupbys':
-                    case 'header':
-                    case 'imports':
-                    case 'operatorId':
-                    case 'matchMode':
-                    case 'measures':
-                    case 'metadata-record':
-                    case 'metadata-records':
-                    case 'method':
-                    case 'output':
-                    case 'orderbys':
-                    case 'predicate':
-                    case 'residuals':
-                    case 'restrictions':
-                    case 'runquery-columns':
-                    case 'segment':
-                    case 'selects':
-                    case 'schema':
-                    case 'tid':
-                    case 'top':
-                    case 'tuples':
-                    case 'values':
-                        streamline(d);
-                        return;
-                    default:
-                        break;
-                }
-            }
-            if (d.symbol) {
-                switch (d.symbol) {
-                    case 'table-symbol':
-                        collapseChildren(d);
-                        return;
-                    default:
-                        break;
-                }
-            }
-            if (d.tag) {
-                switch (d.tag) {
-                    case 'header':
-                    case 'values':
-                    case 'tid':
-                        streamline(d);
-                        return;
-                    default:
-                        break;
-                }
+            switch (d.tag) {
+                case 'aggregates':
+                case 'builder':
+                case 'cardinality':
+                case 'condition':
+                case 'criterion':
+                case 'from':
+                case 'header':
+                case 'output':
+                case 'residuals':
+                case 'restrictions':
+                case 'segment':
+                case 'schema':
+                case 'tid':
+                case 'values':
+                    streamline(d);
+                    return;
+                case "tablescan":
+                case "cursorscan":
+                case "tdescan":
+                case "tableconstruction":
+                case "virtualtable":
+                    collapseChildren(d);
+                    return;
+                default:
+                    break;
             }
         }, function(d) {
             return d.children && d.children.length > 0 ? d.children.slice(0) : null;

--- a/d3/tableau.js
+++ b/d3/tableau.js
@@ -41,7 +41,6 @@ function convertJSON(node) {
     };
 }
 
-
 // Function to generate nodes' display names based on their properties
 var generateDisplayNames = (function() {
     // properties.class are the expressions
@@ -337,7 +336,7 @@ var generateDisplayNames = (function() {
 
 // Assign symbols & classes to the nodes
 function assignSymbolsAndClasses(treeData) {
-    common.visit(treeData,function(n) {
+    common.visit(treeData, function(n) {
         // Assign symbols
         if (n.properties && n.properties.join && n.class && n.class === "join") {
             n.symbol = n.properties.join + "-join-symbol";
@@ -349,14 +348,14 @@ function assignSymbolsAndClasses(treeData) {
             n.symbol = "run-query-symbol";
         }
         // Assign classes for incoming edge
-        if (n.tag == "binding" || n.class == "createtemptable") {
+        if (n.tag === "binding" || n.class === "createtemptable") {
             n.children.forEach(function(c) {
-                c.edgeClass="link-and-arrow";
+                c.edgeClass = "link-and-arrow";
             });
-        } else if (n.name == "runquery") {
+        } else if (n.name === "runquery") {
             n.children.forEach(function(c) {
-                if (c.class=="createtemptable") {
-                   c.edgeClass="dotted-link";
+                if (c.class === "createtemptable") {
+                    c.edgeClass = "dotted-link";
                 }
             });
         }
@@ -429,22 +428,22 @@ function prepareTreeData(treeData, graphCollapse) {
 }
 
 function loadTableauPlan(graphString, graphCollapse) {
-   var result;
-   var parser = new xml2js.Parser({
-       explicitRoot: false,
-       explicitChildren: true,
-       preserveChildrenOrder: true,
-       // Don't merge attributes. XML attributes will be stored in node["$"]
-       mergeAttrs: false
-   });
-   parser.parseString(graphString, function(err,parsed) {
-       if (err) {
-           result={"error": "XML parse failed with '" + err + "'."};
-       } else {
-           result=prepareTreeData(parsed, graphCollapse);
-       }
-   });
-   return result;
+    var result;
+    var parser = new xml2js.Parser({
+        explicitRoot: false,
+        explicitChildren: true,
+        preserveChildrenOrder: true,
+        // Don't merge attributes. XML attributes will be stored in node["$"]
+        mergeAttrs: false
+    });
+    parser.parseString(graphString, function(err, parsed) {
+        if (err) {
+            result = {error: "XML parse failed with '" + err + "'."};
+        } else {
+            result = prepareTreeData(parsed, graphCollapse);
+        }
+    });
+    return result;
 }
 
 exports.loadTableauPlan = loadTableauPlan;

--- a/d3/tableau.js
+++ b/d3/tableau.js
@@ -373,60 +373,35 @@ function collapseNodes(treeData, graphCollapse) {
             if (d.name) {
                 var _name = d.fullName ? d.fullName : d.name;
                 switch (_name) {
-                    case 'aggregates':
-                    case 'builder':
-                    case 'cardinality':
                     case 'condition':
                     case 'conditions':
-                    case 'count':
-                    case 'criterion':
                     case 'datasource':
                     case 'expressions':
                     case 'field':
-                    case 'from':
                     case 'groupbys':
-                    case 'header':
                     case 'imports':
-                    case 'operatorId':
-                    case 'matchMode':
                     case 'measures':
                     case 'metadata-record':
                     case 'metadata-records':
-                    case 'method':
-                    case 'output':
                     case 'orderbys':
                     case 'predicate':
-                    case 'residuals':
                     case 'restrictions':
                     case 'runquery-columns':
-                    case 'segment':
                     case 'selects':
                     case 'schema':
                     case 'tid':
                     case 'top':
                     case 'tuples':
-                    case 'values':
                         streamline(d);
                         return;
                     default:
                         break;
                 }
             }
-            if (d.symbol) {
-                switch (d.symbol) {
-                    case 'table-symbol':
+            if (d.class) {
+                switch (d.class) {
+                    case 'relation':
                         collapseChildren(d);
-                        return;
-                    default:
-                        break;
-                }
-            }
-            if (d.tag) {
-                switch (d.tag) {
-                    case 'header':
-                    case 'values':
-                    case 'tid':
-                        streamline(d);
                         return;
                     default:
                         break;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebundle-tlv": "npm run bundle-uglify",
     "bundle-tlv": "tar -czf $npm_package_name-tlv-qt-$npm_package_version.tgz -C d3 query-graphs.tlv.html query-graphs.css query-graphs.min.js",
     "postinstall": "npm run bundle-tlv",
-    "lint": "eslint upload-server.js d3/query-graphs.js d3/common.js d3/colors.js d3/hyper.js"
+    "lint": "eslint upload-server.js d3/query-graphs.js d3/common.js d3/colors.js d3/hyper.js d3/tableau.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request contains the following 3 commits:

----

Refactoring: Cleanup interface to graph rendering

This is pretty much a refactoring commit. This commit contains the following non-user-facing changes:
* document the internal representation of tree nodes
* move federated coloring logic out of prepareTree and only call it for Tableau query graphs
* So far, drawQueryTree inspected the tree and chose the node's symboland CSS classes for nodes and edges by interpreting Tableau's query properties directly. E.g., drawQueryTree knew about federated queries and how to assign CSS classes to the nodes based on this. With this commit, drawQueryTree no longer infers symbols & CSS classes for nodes and edges directly. It relies on `symbol`, `nodeClass` and `edgeClass`. This way, the individual loaders are able to take decisions such as node coloring and used symbols independently of each other.
* collapsing is now moved into the loaders. This way, Hyper plans and Tableau plan can use independent logic to collapse nodes. For now, both just use the same duplicated logic.

The only user-facing change is that Hyper plans no longer contain the `class`=`relation` property for tablescans, virtualtable and a few others. So far, this property was used to make sure to render the node with the table symbol. Since choosing the symbol is now independent from the `class` property, we no longer need to set it. In addition, the `class`=`relation` was displayed in the tool-tip. The class=relation is no longer in the tooltip. Similarly, for joins the `class` and the `join` properties are no longer used.

----

Refactoring: Cleanup collapsing logic

In the previous commit, the collapsing logic was moved from the main file into the loaders. The previous commit simply duplicated the collapsing logic. This commit now detangles the parts of the logic used for Hyper from the logic used for Tableau.

----

Make linter happy for tableau.js file