### PR TITLE
Allow to show additional fields in the tree label

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ debug           | debug mode: any setting will enable (disabled by default)
 file            | name of XML file: (default file name if not specified)
 orientation     | graph orientation: top-to-bottom (default), right-to-left, bottom-to-top, left-to-right
 upload          | query uploaded: y - query was uploaded to the visualization service, n - (default)
+properties      | JSON object with additional properties to be displayed in the tree label
 
 ```
 

--- a/d3/hyper.js
+++ b/d3/hyper.js
@@ -336,17 +336,21 @@ function collapseNodes(treeData, graphCollapse) {
 
 // Loads a Hyper query plan
 function loadHyperPlan(graphString, graphCollapse) {
-    var treeData;
+    var json;
     try {
-        treeData = JSON.parse(graphString);
+        json = JSON.parse(graphString);
     } catch (err) {
         return {error: "JSON parse failed with '" + err + "'."};
     }
-    treeData = convertHyper(treeData, "result");
-    generateDisplayNames(treeData);
-    common.createParentLinks(treeData);
-    collapseNodes(treeData, graphCollapse);
-    return treeData;
+    var properties = {};
+    if (json.hasOwnProperty("plan") && json.plan.hasOwnProperty("header")) {
+        properties.columns = json.plan.header.length / 2;
+    }
+    var root = convertHyper(json, "result");
+    generateDisplayNames(root);
+    common.createParentLinks(root);
+    collapseNodes(root, graphCollapse);
+    return {root: root, properties: properties};
 }
 
 exports.loadHyperPlan = loadHyperPlan;

--- a/d3/tableau.js
+++ b/d3/tableau.js
@@ -440,7 +440,7 @@ function loadTableauPlan(graphString, graphCollapse) {
         if (err) {
             result = {error: "XML parse failed with '" + err + "'."};
         } else {
-            result = prepareTreeData(parsed, graphCollapse);
+            result = {root: prepareTreeData(parsed, graphCollapse)};
         }
     });
     return result;


### PR DESCRIPTION
The tree label (displayed in the top-right corner of the canvas)
contained a hardcoded set of infos, so far. With this commit, two
sources are used to propagate the information displayed in this label:
* Information can be added using the `properties` query parameter.
  This is useful, e.g., for Tableau Log Viewer such that it can augment
  the tree with meta information such as the current optimizer
  step/rewrite or the query execution time.
* The loaders can contribute information. E.g., the Hyper query
  plan loader uses this to display the number of returned columns.