### PR TITLE
Adapters for raw XML and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Parameter       | Description
 collapse        | node collapse style: n - no/none, y - yes/some, s - streamline all secondary nodes (default)
 debug           | debug mode: any setting will enable (disabled by default)
 file            | name of XML file: (default file name if not specified)
+format          | format of the file: 'tableau', 'hyper', 'xml', 'json' (default: file format will be inferred)
 orientation     | graph orientation: top-to-bottom (default), right-to-left, bottom-to-top, left-to-right
 upload          | query uploaded: y - query was uploaded to the visualization service, n - (default)
 properties      | JSON object with additional properties to be displayed in the tree label

--- a/d3/common.js
+++ b/d3/common.js
@@ -64,8 +64,35 @@ function streamline(d) {
     }
 }
 
+// Convert to string. Return undefined if not supported.
+function toString(d) {
+    if (typeof (d) === "string") {
+        return d;
+    } else if (typeof (d) === "number") {
+        return d.toString();
+    } else if (typeof (d) === "boolean") {
+        return d.toString();
+    } else if (d === null) {
+        return "null";
+    } else if (d === undefined) {
+        return "undefined";
+    }
+    return undefined;
+}
+
+// Convert to string. Returns the JSON serialization if not supported.
+function forceToString(d) {
+    var str = toString(d);
+    if (str === undefined) {
+        str = JSON.stringify(d);
+    }
+    return str;
+}
+
 exports.visit = visit;
 exports.allChildren = allChildren;
 exports.createParentLinks = createParentLinks;
 exports.collapseChildren = collapseChildren;
 exports.streamline = streamline;
+exports.toString = toString;
+exports.forceToString = forceToString;

--- a/d3/hyper.js
+++ b/d3/hyper.js
@@ -30,31 +30,6 @@ Miscellaneous
 
 var common = require('./common');
 
-// Convert to string. Return undefined if not supported.
-function toString(d) {
-    if (typeof (d) === "string") {
-        return d;
-    } else if (typeof (d) === "number") {
-        return d.toString();
-    } else if (typeof (d) === "boolean") {
-        return d.toString();
-    } else if (d === null) {
-        return "null";
-    } else if (d === undefined) {
-        return "undefined";
-    }
-    return undefined;
-}
-
-// Convert to string. Returns the JSON serialization if not supported.
-function forceToString(d) {
-    var str = toString(d);
-    if (str === undefined) {
-        str = JSON.stringify(d);
-    }
-    return str;
-}
-
 // Convert Hyper JSON to a D3 tree
 function convertHyper(node, tag) {
     var innerNode;
@@ -104,7 +79,7 @@ function convertHyper(node, tag) {
             if (!node.hasOwnProperty(key)) {
                 return;
             }
-            properties[key] = forceToString(node[key]);
+            properties[key] = common.forceToString(node[key]);
         });
 
         // Display all other properties adaptively: simple expressions are displayed as properties, all others as part of the tree
@@ -115,7 +90,7 @@ function convertHyper(node, tag) {
             }
 
             // Try to display as string property
-            var str = toString(node[key]);
+            var str = common.toString(node[key]);
             if (str !== undefined) {
                 properties[key] = str;
                 return;
@@ -158,10 +133,10 @@ function convertHyper(node, tag) {
             }
         });
         return listOfObjects;
-    } else if (toString(node) !== undefined) {
+    } else if (common.toString(node) !== undefined) {
         return {
             tag: tag,
-            text: toString(node)
+            text: common.toString(node)
         };
     }
     console.warn("Convert to JSON case not implemented");

--- a/d3/json.js
+++ b/d3/json.js
@@ -1,0 +1,53 @@
+/*
+
+JSON Loader
+--------------------------
+
+Map the JSON tree directly to a D3 tree, without any modifications
+
+*/
+
+var common = require('./common');
+
+function convertChildren(node) {
+    var children;
+    if (common.toString(node) !== undefined) {
+        return [{
+            name: common.toString(node) + ":" + typeof node,
+            properties: {
+                value: common.toString(node),
+                type: typeof node
+            }
+        }];
+    } else if (typeof (node) === "object" && !Array.isArray(node)) {
+        // "Object" nodes
+        children = [];
+        Object.getOwnPropertyNames(node).sort().forEach(function(key) {
+            children.push({name: key, children: convertChildren(node[key])});
+        });
+        return children;
+    } else if (Array.isArray(node)) {
+        // "Array" nodes
+        children = [];
+        node.forEach(function(value, index) {
+            children.push({name: String(index), children: convertChildren(node[index])});
+        });
+        return children;
+    }
+    console.warn("Unhandled JSON type");
+    return [{name: JSON.stringify(node)}];
+}
+
+// Load a JSON tree
+function loadJson(graphString, _graphCollapse) {
+    var json;
+    try {
+        json = JSON.parse(graphString);
+    } catch (err) {
+        return {error: "JSON parse failed with '" + err + "'."};
+    }
+    var root = {name: "root", children: convertChildren(json)};
+    return {root: root};
+}
+
+exports.loadJson = loadJson;

--- a/d3/query-graphs.css
+++ b/d3/query-graphs.css
@@ -157,6 +157,18 @@ html, body {
   box-shadow: 2px 2px 2px #888;
 }
 
+.prop-name {
+  color: hsl(309, 84%, 36%);
+}
+
+.prop-name2 {
+  color: hsl(0, 0%, 50%);
+}
+
+.prop-value {
+  color: black;
+}
+
 .link {
   fill: none;
   stroke: #ccc;

--- a/d3/xml.js
+++ b/d3/xml.js
@@ -1,0 +1,61 @@
+/*
+
+XML Loader
+--------------------------
+
+Map the XML tree directly to a D3 tree, without any modifications.
+Elements are displayed as tree nodes and the attributes are shown
+in the tooltips.
+
+*/
+
+// Require node modules
+var xml2js = require('xml2js');
+
+// Convert JSON as returned by xml2js parser to d3 tree format
+function convertJSON(node) {
+    var children = [];
+    var properties = {};
+    var text;
+    var tag = node["#name"];
+
+    if (node.$) {
+        properties = node.$;
+    }
+    if (node._) {
+        text = node._;
+    }
+    if (node.$$) {
+        node.$$.forEach(function(child) {
+            children.push(convertJSON(child));
+        });
+    }
+
+    return {
+        name: tag,
+        properties: properties,
+        text: text,
+        children: children
+    };
+}
+
+function loadXml(graphString, _graphCollapse) {
+    var result;
+    var parser = new xml2js.Parser({
+        explicitRoot: false,
+        explicitChildren: true,
+        preserveChildrenOrder: true,
+        // Don't merge attributes. XML attributes will be stored in node["$"]
+        mergeAttrs: false
+    });
+    parser.parseString(graphString, function(err, parsed) {
+        if (err) {
+            result = {error: "XML parse failed with '" + err + "'."};
+        } else {
+            result = {root: convertJSON(parsed)};
+        }
+    });
+    return result;
+}
+
+exports.loadXml = loadXml;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebundle-tlv": "npm run bundle-uglify",
     "bundle-tlv": "tar -czf $npm_package_name-tlv-qt-$npm_package_version.tgz -C d3 query-graphs.tlv.html query-graphs.css query-graphs.min.js",
     "postinstall": "npm run bundle-tlv",
-    "lint": "eslint upload-server.js d3/query-graphs.js d3/common.js d3/colors.js d3/hyper.js d3/tableau.js"
+    "lint": "eslint upload-server.js d3/query-graphs.js d3/common.js d3/colors.js d3/hyper.js d3/tableau.js d3/json.js d3/xml.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adapters for raw XML and JSON

During improving the way we render hyper query graphs, it turned out to be quite useful to see how the JSON looked before transforming it. This commit adds support for loading XML and JSON documents directly and to just display their raw structure - without any domain-specific beautifications applied. To trigger them, the newly introduced parameter `format` allows to specify a format directly instead of relying on the file format heuristic.

----

Hide empty tooltips

There is no point in displaying empty tooltips, so let's just hide them.