### PR TITLE
Hyper plans: Show cardinalities as labels on the edges

### DIFF
--- a/d3/common.js
+++ b/d3/common.js
@@ -89,6 +89,17 @@ function forceToString(d) {
     return str;
 }
 
+// Format a number using metric suffixes
+function formatMetric(x) {
+    var sizes = ["", "k", "M", "G", "T", "E", "P"];
+    var idx = 0;
+    while (x > 1000 && idx < sizes.length) {
+        x /= 1000;
+        ++idx;
+    }
+    return x.toFixed(0) + sizes[idx];
+}
+
 exports.visit = visit;
 exports.allChildren = allChildren;
 exports.createParentLinks = createParentLinks;
@@ -96,3 +107,4 @@ exports.collapseChildren = collapseChildren;
 exports.streamline = streamline;
 exports.toString = toString;
 exports.forceToString = forceToString;
+exports.formatMetric = formatMetric;

--- a/d3/hyper.js
+++ b/d3/hyper.js
@@ -105,11 +105,14 @@ function convertHyper(node, tag) {
             }
             return;
         });
+        // Display the cardinality on the links between the nodes
+        var edgeLabel = node.hasOwnProperty("cardinality") ? common.formatMetric(node.cardinality) : undefined;
         // Build the converted node
         var convertedNode = {
             tag: tag,
             properties: properties,
-            children: children
+            children: children,
+            edgeLabel: edgeLabel
         };
         if (tagOverride !== undefined) {
             convertedNode.tag = tagOverride;

--- a/d3/query-graphs.css
+++ b/d3/query-graphs.css
@@ -189,6 +189,13 @@ marker#arrow {
   fill: #ccc;
 }
 
+.link-label {
+  font-size: 7px;
+  font-weight: bold;
+  font-family: Monaco, Consolas, monospace;
+  fill: #aaa;
+}
+
 /* Run Query */
 path.run-query {
   fill: #fff;


### PR DESCRIPTION
With this commit, the cardinality estimates are shown as labels on the
edges.

<img width="415" alt="screen shot 2017-12-13 at 19 43 19" src="https://user-images.githubusercontent.com/6820896/33956201-21efa528-e03e-11e7-8290-a7990400ec22.png">
