### PR TITLE
More compact rendering of expressions within Hyper plans

### DIFF
--- a/d3/query-graphs.js
+++ b/d3/query-graphs.js
@@ -520,7 +520,7 @@ function drawQueryTree(treeData) {
     }
 
     // Helper function to retrieve all properties of the node object which should be rendered in the tooltip
-    var alwaysSuppressedKeys = ["properties", "parent", "properties", "symbol", "nodeClass", "edgeClass", "edgeLabel"];
+    var alwaysSuppressedKeys = ["name", "properties", "parent", "properties", "symbol", "nodeClass", "edgeClass", "edgeLabel"];
     var debugTooltipKeys = ["_children", "children", "_name", "depth", "id", "x", "x0", "y", "y0"];
     function getDirectProperties(d) {
         var props = {};


### PR DESCRIPTION
While the previous changes made it easier to see the overall plan
structure by moving information of lower interest from the tree into
the tooltips, the related changes of the query plan loading made some
expresssion trees harder to read.

E.g., expression trees now had explicit `left` and `right` nodes in the
tree for their arguments and IUrefs were no longer labeled with the
IU name.

This commit fixes the overall algorithm such that explicit nodes are
inserted only if a we encountered an unexpected key in the JSON plan.
Since, `left` and `right` are well-known keys, this means that we don't
add them as explicit nodes. On the other hand, we now create a node for
uncommon keys such as `magic`.

In addition, this commit contains a few minor fixes such as using the
IU name as the label for iurefs.

----

Expression tree before:
<img width="962" alt="screen shot 2017-12-17 at 23 10 23" src="https://user-images.githubusercontent.com/6820896/34084396-e197dd02-e37f-11e7-8651-5babf4ebc612.png">

Expression tree with this change:
<img width="963" alt="screen shot 2017-12-17 at 23 08 56" src="https://user-images.githubusercontent.com/6820896/34084399-e84824cc-e37f-11e7-8845-9354c6ac00bc.png">

Note, how there are no more `left` and `right` nodes in the tree.
The overall number of nodes increased, nevertheless. E.g. the way `const` nodes are rendered uses more nodes now.