### PR TITLE
Better error handling

### DIFF
--- a/d3/query-graphs.css
+++ b/d3/query-graphs.css
@@ -4,7 +4,7 @@ html, body {
   height: 100%;
   overflow: hidden;
 }
-#tree-container {
+.tree-container {
   padding: 0px;
   width: 100%;
   height: 100%;
@@ -12,7 +12,7 @@ html, body {
   margin: 0 auto;
 }
 
-#tree-label {
+.tree-label {
   margin: 0 auto;
   position: fixed;
   top: 3px;

--- a/d3/query-graphs.html
+++ b/d3/query-graphs.html
@@ -1,40 +1,34 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-
-<title>Query Visualization</title>
-
-<!-- http://realfavicongenerator.net/ -->
-<link rel="apple-touch-icon" sizes="57x57" href="icons/apple-touch-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="icons/apple-touch-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="icons/apple-touch-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="icons/apple-touch-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="icons/apple-touch-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="icons/apple-touch-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="icons/apple-touch-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="icons/apple-touch-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon-180x180.png">
-<link rel="icon" type="image/png" href="icons/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="icons/android-chrome-192x192.png" sizes="192x192">
-<link rel="icon" type="image/png" href="icons/favicon-96x96.png" sizes="96x96">
-<link rel="icon" type="image/png" href="icons/favicon-16x16.png" sizes="16x16">
-<link rel="manifest" href="icons/manifest.json">
-<link rel="mask-icon" href="icons/safari-pinned-tab.svg" color="#4682b4">
-<link rel="shortcut icon" href="icons/favicon.ico">
-<meta name="msapplication-TileColor" content="#eeeeee">
-<meta name="msapplication-TileImage" content="icons/mstile-144x144.png">
-<meta name="msapplication-config" content="icons/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
-
-<!-- main style sheet  -->
-<link href='query-graphs.css' rel='stylesheet' type='text/css'>
-
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Query Visualization</title>
+    <!-- http://realfavicongenerator.net/ -->
+    <link rel="apple-touch-icon" sizes="57x57" href="icons/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="icons/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="icons/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="icons/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="icons/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="icons/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="icons/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="icons/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon-180x180.png">
+    <link rel="icon" type="image/png" href="icons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="icons/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="icons/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="icons/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="icons/manifest.json">
+    <link rel="mask-icon" href="icons/safari-pinned-tab.svg" color="#4682b4">
+    <link rel="shortcut icon" href="icons/favicon.ico">
+    <meta name="msapplication-TileColor" content="#eeeeee">
+    <meta name="msapplication-TileImage" content="icons/mstile-144x144.png">
+    <meta name="msapplication-config" content="icons/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
+    <!-- main style sheet  -->
+    <link href='query-graphs.css' rel='stylesheet' type='text/css'>
+</head>
 <body>
-    <div id="tree-container">
-        <div id="tree-label">
-        </div>
-    </div>
 </body>
-</html>
-
 <!-- bundle created by browserify -->
 <script src="query-graphs.bundle.js"></script>
+</html>

--- a/d3/query-graphs.tlv.html
+++ b/d3/query-graphs.tlv.html
@@ -5,10 +5,6 @@
 <link href='query-graphs.css' rel='stylesheet' type='text/css'>
 
 <body>
-    <div id="tree-container">
-        <div id="tree-label">
-        </div>
-    </div>
 </body>
 </html>
 


### PR DESCRIPTION
So far, most error messages were not visible to the users since they
were clobbered by subsequent modifications to the tree, e.g. by showing
the spinner. Furthermore, error messages were positioned after the
`tree-container` and thereby pushed below the fold and completely
invisible due to the `overflow: hidden` applied to the body.

This commit solves the issues by
* making sure that we do not proceed rendering if parameter parsing
  failed
* creating `tree-container` and `tree-label` lazily. Thereby, the error
  messages remain visible

Also, this commit rewrites the query-graphs.html file to make it HTML-compliant.

Fixes issues #19, #23