### PR TITLE
Better collapsing for Hyper plans

### DIFF
--- a/d3/common.js
+++ b/d3/common.js
@@ -39,17 +39,22 @@ function createParentLinks(tree) {
 }
 
 // Collapse all children regardless of the current state
-function collapseChildren(d) {
-    var children = (d.children) ? d.children : null;
-    var _children = (d._children) ? d._children : null;
-    // all original children are in _children or none are
-    if (_children === null || _children.length === 0) {
-        d._children = children;
-    }
-    d.children = null;
+function collapseAllChildren(d) {
+    var children = (d.children) ? d.children : [];
+    var _children = (d._children) ? d._children : [];
+    d.children = null
+    d._children = children.length > _children.length ? children : _children;
     return d;
 }
 
+// Expand all children regardless of the current state
+function expandAllChildren(d) {
+    var children = (d.children) ? d.children : [];
+    var _children = (d._children) ? d._children : [];
+    d.children = children.length > _children.length ? children : _children;
+    d._children = null;
+    return d;
+}
 // Collapse the given node in its parent node
 // Requires parent links to be present (e.g., created by `createParentLinks`)
 function streamline(d) {
@@ -103,7 +108,8 @@ function formatMetric(x) {
 exports.visit = visit;
 exports.allChildren = allChildren;
 exports.createParentLinks = createParentLinks;
-exports.collapseChildren = collapseChildren;
+exports.collapseAllChildren = collapseAllChildren;
+exports.expandAllChildren = expandAllChildren;
 exports.streamline = streamline;
 exports.toString = toString;
 exports.forceToString = forceToString;

--- a/d3/tableau.js
+++ b/d3/tableau.js
@@ -365,8 +365,8 @@ function assignSymbolsAndClasses(treeData) {
 }
 
 function collapseNodes(treeData, graphCollapse) {
-    var streamline = graphCollapse === "s" ? common.streamline : common.collapseChildren;
-    var collapseChildren = common.collapseChildren;
+    var streamline = graphCollapse === "s" ? common.streamline : common.collapseAllChildren;
+    var collapseAllChildren = common.collapseAllChildren;
     if (graphCollapse !== 'n') {
         common.visit(treeData, function(d) {
             if (d.name) {
@@ -400,7 +400,7 @@ function collapseNodes(treeData, graphCollapse) {
             if (d.class) {
                 switch (d.class) {
                     case 'relation':
-                        collapseChildren(d);
+                        collapseAllChildren(d);
                         return;
                     default:
                         break;

--- a/media/favorites/hyper/tablefunction.json
+++ b/media/favorites/hyper/tablefunction.json
@@ -1,0 +1,18 @@
+{
+  "plan": {
+    "operator": "tablefunction",
+    "operatorId": 1,
+    "cardinality": 10,
+    "input": {
+      "operator": "tableconstruction",
+      "operatorId": 2,
+      "cardinality": 1,
+      "output": [],
+      "values": [[]]
+    },
+    "function": "sequence",
+    "args": [{"expression": "const", "value": {"type": ["Integer"], "value": 1}}, {"expression": "const", "value": {"type": ["Integer"], "value": 10}}],
+    "ius": [["v", ["Integer"]]]
+  },
+  "header": ["generate_series", "v"]
+}


### PR DESCRIPTION
So far, the keys which should be collapsed in a Hyper plan were
hardcoded. Since a few (uncommon) operators like tablefunction and
explicitscan were not taken into account, those operators were
displayed poorly.

With this change, we no longer ship a hardcoded list of keys which
should be collapsed. Instead, we now:
* for expressions: collapse no children at all. This is the same
  behavior as before.
* for operators: collapse all children except for a few selected
  children such as "left" and "right".

With this change, we now display also uncommon operators nicely.
At the same time, we will not have to update the lists of collapsed
keys when Hyper devs add new functionality.