### PR TITLE
Add query plans featuring CTEs and magic sets

### DIFF
--- a/media/favorites/hyper/cte.json
+++ b/media/favorites/hyper/cte.json
@@ -1,0 +1,36 @@
+{
+  "query": "WITH t1 AS (VALUES(1),(2),(3)) SELECT * FROM t1 ta,t1 tb",
+  "plan": {
+    "operator": "join",
+    "operatorId": 1,
+    "cardinality": 9,
+    "method": "bnl",
+    "left": {
+      "operator": "explicitscan",
+      "operatorId": 2,
+      "cardinality": 3,
+      "output": [{"source": ["v", ["Integer"]], "target": ["v2", ["Integer"]]}],
+      "source": {
+        "operator": "temp",
+        "operatorId": 3,
+        "cardinality": 3,
+        "input": {
+          "operator": "tableconstruction",
+          "operatorId": 4,
+          "cardinality": 3,
+          "output": [["v", ["Integer"]]],
+          "values": [[{"expression": "const", "value": {"type": ["Integer"], "value": 1}}], [{"expression": "const", "value": {"type": ["Integer"], "value": 2}}], [{"expression": "const", "value": {"type": ["Integer"], "value": 3}}]]
+        }
+      }
+    },
+    "right": {
+      "operator": "explicitscan",
+      "operatorId": 5,
+      "cardinality": 3,
+      "output": [{"source": "v", "target": ["v3", ["Integer"]]}],
+      "source": 3
+    },
+    "condition": {"expression": "const", "value": {"type": ["Bool"], "value": true}}
+  },
+  "header": ["1", "v3", "1", "v2"]
+}

--- a/media/favorites/hyper/magicunnesting.json
+++ b/media/favorites/hyper/magicunnesting.json
@@ -1,0 +1,65 @@
+{
+  "query": "SELECT a, (SELECT SUM(b) FROM b WHERE b < a) FROM a",
+  "plan": {
+    "operator": "leftouterjoin",
+    "operatorId": 1,
+    "cardinality": 2000,
+    "method": "hash",
+    "left": {
+      "operator": "tablescan",
+      "operatorId": 2,
+      "cardinality": 2000,
+      "relationId": 0,
+      "from": "a",
+      "values": [{"name": "a", "type": ["Integer"], "iu": ["scan_a", ["Integer"]]}],
+      "tid": null,
+      "tableOid": null,
+      "tupleFlags": null,
+      "restrictions": []
+    },
+    "right": {
+      "operator": "groupby",
+      "operatorId": 3,
+      "cardinality": 100,
+      "input": {
+        "operator": "join",
+        "operatorId": 4,
+        "cardinality": 100000,
+        "method": "bnl",
+        "left": {
+          "operator": "explicitscan",
+          "operatorId": 5,
+          "cardinality": 100,
+          "output": [{"source": ["keep", ["Integer"]], "target": ["keep2", ["Integer"]]}],
+          "source": {
+            "operator": "groupby",
+            "operatorId": 6,
+            "cardinality": 100,
+            "behavior": "regular",
+            "values": [{"value": {"expression": "iuref", "iu": "scan_a"}}],
+            "aggregates": [{"source": 0, "operation": "keep", "iu": ["keep", ["Integer"]]}]
+          }
+        },
+        "right": {
+          "operator": "tablescan",
+          "operatorId": 7,
+          "cardinality": 2000,
+          "relationId": 1,
+          "from": "b",
+          "values": [{"name": "b", "type": ["Integer"], "iu": ["scan_b", ["Integer"]]}],
+          "tid": null,
+          "tableOid": null,
+          "tupleFlags": null,
+          "restrictions": []
+        },
+        "condition": {"expression": "comparison", "mode": "<", "left": {"expression": "iuref", "iu": "scan_b"}, "right": {"expression": "iuref", "iu": "keep2"}}
+      },
+      "behavior": "regular",
+      "values": [{"value": {"expression": "iuref", "iu": "scan_b"}}, {"value": {"expression": "iuref", "iu": "keep2"}}],
+      "aggregates": [{"source": 1, "operation": "keep", "iu": ["keep3", ["Integer"]]}, {"source": 0, "operation": "sum", "iu": ["sum", ["BigInt", "nullable"]]}]
+    },
+    "condition": {"expression": "comparison", "mode": "is", "left": {"expression": "iuref", "iu": "scan_a"}, "right": {"expression": "iuref", "iu": "keep3"}},
+    "magic": 6
+  },
+  "header": ["a", "scan_a", "2", "sum"]
+}


### PR DESCRIPTION
This commit adds two simple query plans featuring two of Hyper's
more advanced features:
* Common table expressions (CTEs)
* Magic sets which are used to unnest correlated subqueries