### PR TITLE
Replace uses of includes with indexOf function. 

### DIFF
--- a/d3/query-graphs.js
+++ b/d3/query-graphs.js
@@ -885,7 +885,7 @@ function drawQueryTree(target, treeData) {
         // Update crosslinks
         if (crosslinks !== undefined && crosslinks.length) {
             var visibleCrosslinks = crosslinks.filter(function(d) {
-                return nodes.includes(d.source) && nodes.includes(d.target);
+                return nodes.indexOf(d.source) !== -1 && nodes.indexOf(d.target) !== -1;
             });
 
             // Helper function to update crosslink paths


### PR DESCRIPTION
The Qt Web Viewer doesn't support the includes function.
This was causing queries with cross-links to not render correctly in TLV (which uses the QT WebViewer control). Graphs were not affected in browsers.