### PR TITLE
Fix links displayed on `favorites` list

### DIFF
--- a/upload-server.js
+++ b/upload-server.js
@@ -152,7 +152,7 @@ app.get("/favorites", function(req, res) {
             for (var j = commonLen; j < relPath.length; ++j) {
                 html += "<li>" + escapeHtml(relPath[j]) + "<ul>";
             }
-            html += "<li><a href='d3/query-graphs.html?file=" +
+            html += "<li><a href='/d3/query-graphs.html?file=" +
                     encodeURIComponent(relName) + "'>" + escapeHtml(fileName) + "</a></li>";
             lastPath = relPath;
         });


### PR DESCRIPTION
The favorites list was reachable both through `/favorites` and
`/favorites/`. Since the links did not contain a leading `/`, they were
interpreted as relative paths. This was fine for `/favorites` but did
not work when the page was opened as `/favorites/`