### PR TITLE
Make tree rendering less verbose

### DIFF
--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -765,7 +765,7 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         nodeUpdate
             .filter(function(d) {
                 return (
-                    Object.getOwnPropertyNames(getDirectProperties(d)).length || // eslint-disable-line indent
+                    Object.getOwnPropertyNames(getDirectProperties(d.data)).length || // eslint-disable-line indent
                     (d.data.hasOwnProperty("properties") && Object.getOwnPropertyNames(d.data.properties).length)
                 );
             }) // eslint-disable-line indent

--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -976,17 +976,18 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
 
     // Add metrics card
     let treeText = "";
-    const properties = treeData.properties ?? {};
-    treeText += buildPropertyList(properties);
-    treeText += buildPropertyList({nodes: totalNodes});
-    if (crosslinks !== undefined && crosslinks.length) {
-        treeText += buildPropertyList({crosslinks: crosslinks.length});
+    treeText += buildPropertyList(treeData.properties ?? {});
+    if (DEBUG) {
+        const debugProps = {nodes: totalNodes, crosslinks: crosslinks.length};
+        treeText += buildPropertyList(debugProps, "qg-prop-name2");
     }
-    d3selection
-        .select(target)
-        .append("div")
-        .classed("qg-tree-label", true)
-        .html(treeText);
+    if (treeText != "") {
+        d3selection
+            .select(target)
+            .append("div")
+            .classed("qg-tree-label", true)
+            .html(treeText);
+    }
 
     function expandOneLevel() {
         svgGroup.selectAll("g.qg-node").each(function(d) {


### PR DESCRIPTION
These two commits are both about displaying less information, in particular about hiding irrelevant tooltips and irrelevant statistics about the rendered tree