### PR TITLE
Improved rendering for virtualtables and filters

### DIFF
--- a/query-graphs/package.json
+++ b/query-graphs/package.json
@@ -57,8 +57,7 @@
   "scripts": {
     "build": "tsc --build",
     "test": "env TS_NODE_PROJECT=\"tsconfig.testing.json\" mocha -r ts-node/register --recursive src/**/*.test.ts",
-    "lint": "eslint .",
-    "typescript": "^3.8.3"
+    "lint": "eslint ."
   },
   "sideEffects": false
 }

--- a/query-graphs/src/hyper.ts
+++ b/query-graphs/src/hyper.ts
@@ -168,35 +168,40 @@ function generateDisplayNames(treeRoot: TreeNode) {
     treeDescription.visitTreeNodes(
         treeRoot,
         function(node) {
+            node.name = node.tag ?? node.text ?? "";
             switch (node.tag) {
                 case "join":
-                    node.name = node.tag;
                     node.symbol = "inner-join-symbol";
                     break;
                 case "leftouterjoin":
-                    node.name = node.tag;
                     node.symbol = "left-join-symbol";
                     break;
                 case "rightouterjoin":
-                    node.name = node.tag;
                     node.symbol = "right-join-symbol";
                     break;
                 case "fullouterjoin":
-                    node.name = node.tag;
                     node.symbol = "full-join-symbol";
                     break;
                 case "tablescan":
-                    node.name = node.properties.from ? node.properties.from : node.tag;
+                    node.name = node.properties.from ?? node.tag;
                     node.symbol = "table-symbol";
+                    break;
+                case "virtualtable":
+                    node.name = node.properties.name ?? node.tag;
+                    node.symbol = "virtual-table-symbol";
+                    break;
+                case "tableconstruction":
+                    node.symbol = "const-table-symbol";
                     break;
                 case "binaryscan":
                 case "cursorscan":
                 case "csvscan":
                 case "tdescan":
-                case "tableconstruction":
-                case "virtualtable":
-                    node.name = node.tag;
                     node.symbol = "table-symbol";
+                    break;
+                case "select":
+                case "earlyprobe":
+                    node.symbol = "filter-symbol";
                     break;
                 case "explicitscan":
                     node.name = node.tag;
@@ -208,14 +213,13 @@ function generateDisplayNames(treeRoot: TreeNode) {
                     node.edgeClass = "qg-link-and-arrow";
                     break;
                 case "comparison":
-                    node.name = node.properties.mode ? node.properties.mode : node.tag;
+                    node.name = node.properties.mode ?? node.tag;
                     break;
                 case "iuref":
-                    node.name = node.properties.iu ? node.properties.iu : node.tag;
+                    node.name = node.properties.iu ?? node.tag;
                     break;
                 case "attribute":
                 case "condition":
-                case "header":
                 case "iu":
                 case "name":
                 case "operation":
@@ -223,8 +227,6 @@ function generateDisplayNames(treeRoot: TreeNode) {
                 case "tableOid":
                 case "tid":
                 case "tupleFlags":
-                case "unique":
-                case "unnormalizedNames":
                 case "output":
                     if (node.text) {
                         node.name = node.tag + ":" + node.text;

--- a/query-graphs/src/tableau.ts
+++ b/query-graphs/src/tableau.ts
@@ -396,6 +396,8 @@ function assignSymbolsAndClasses(root: TreeNode) {
                 n.symbol = "table-symbol";
             } else if (n.class && n.class === "createtemptable") {
                 n.symbol = "temp-table-symbol";
+            } else if (n.tag == "selectOp") {
+                n.symbol = "filter-symbol";
             } else if (n.name && n.name === "runquery") {
                 n.symbol = "run-query-symbol";
             }

--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -15,7 +15,7 @@ const MAX_DISPLAY_LENGTH = 15;
 //
 // Create the symbols
 //
-function defineSymbols(baseSvg, ooo) {
+function defineSymbols(baseSvg) {
     baseSvg.append("svg:defs");
     const defs = baseSvg.select("defs");
     // Build the arrow
@@ -26,7 +26,7 @@ function defineSymbols(baseSvg, ooo) {
         .attr("refY", 0)
         .attr("markerWidth", 5)
         .attr("markerHeight", 5)
-        .attr("orient", ooo.arrowRotation)
+        .attr("orient", "auto-start-reverse")
         .append("svg:path")
         .attr("d", "M0,-5L10,0L0,5");
 
@@ -320,7 +320,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
                     y: d.target.y - crosslinkRawSpacing.direction,
                 };
             },
-            arrowRotation: "270deg",
         },
         "right-to-left": {
             link: d3shape.linkHorizontal,
@@ -363,7 +362,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
                     y: d.target.y + crosslinkRawSpacing.offset,
                 };
             },
-            arrowRotation: "0deg",
         },
         "bottom-to-top": {
             link: d3shape.linkVertical,
@@ -406,7 +404,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
                     y: d.target.y + crosslinkRawSpacing.direction,
                 };
             },
-            arrowRotation: "90deg",
         },
         "left-to-right": {
             link: d3shape.linkHorizontal,
@@ -449,7 +446,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
                     y: d.target.y + crosslinkRawSpacing.offset,
                 };
             },
-            arrowRotation: "180deg",
         },
     };
 
@@ -564,7 +560,7 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         .attr("class", "qg-overlay")
         .call(zoomBehavior);
 
-    defineSymbols(baseSvg, ooo);
+    defineSymbols(baseSvg);
 
     function collapseDefault(r) {
         treeDescription.visitTreeNodes(

--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -33,14 +33,14 @@ function defineSymbols(baseSvg) {
     // Build the default symbol. Use this symbol if there is not a better fit
     defs.append("circle")
         .attr("id", "default-symbol")
-        .attr("class", "qg-node-circle")
+        .attr("class", "qg-symbol-filled")
         .attr("r", 5);
 
     // Build the run query symbol
     const runQueryGroup = defs.append("g").attr("id", "run-query-symbol");
     runQueryGroup
         .append("circle")
-        .attr("class", "qg-node-circle")
+        .attr("class", "qg-symbol-filled")
         .attr("r", 6);
     runQueryGroup
         .append("path")
@@ -177,27 +177,37 @@ function defineSymbols(baseSvg) {
         .attr("y", tableStartTop + tableRowHeight)
         .attr("height", tableHeight - tableRowHeight);
 
-    // Build the temp table symbol, very similar to the regular table symbol
-    const tempTableGroup = defs.append("g").attr("id", "temp-table-symbol");
-    tempTableGroup
-        .append("rect")
-        .attr("class", "qg-table-background")
-        .attr("x", tableStartLeft)
-        .attr("width", tableWidth)
-        .attr("y", tableStartTop)
-        .attr("height", tableHeight);
-    tempTableGroup
-        .append("rect")
-        .attr("class", "qg-table-header")
-        .attr("x", tableStartLeft)
-        .attr("width", tableWidth)
-        .attr("y", tableStartTop)
-        .attr("height", tableRowHeight);
-    tempTableGroup
-        .append("text")
-        .attr("class", "qg-table-text")
-        .attr("y", tableRowHeight + 0.8 /* stroke-width */ / 2)
-        .text("tmp");
+    defs.append("path")
+        .attr("id", "filter-symbol")
+        .attr("class", "qg-symbol-filled")
+        .attr("d", "M-6,-6 L6,-6 L0.8,0 L0.8,5 L-0.8,7 L-0.8,0 Z");
+
+    // Build the additional table symbol, very similar to the regular table symbol
+    function createLabeledTableSymbol(id: string, label: string) {
+        const labeledTableGroup = defs.append("g").attr("id", id);
+        labeledTableGroup
+            .append("rect")
+            .attr("class", "qg-table-background")
+            .attr("x", tableStartLeft)
+            .attr("width", tableWidth)
+            .attr("y", tableStartTop)
+            .attr("height", tableHeight);
+        labeledTableGroup
+            .append("rect")
+            .attr("class", "qg-table-header")
+            .attr("x", tableStartLeft)
+            .attr("width", tableWidth)
+            .attr("y", tableStartTop)
+            .attr("height", tableRowHeight);
+        labeledTableGroup
+            .append("text")
+            .attr("class", "qg-table-text")
+            .attr("y", tableRowHeight + 0.8 /* stroke-width */ / 2)
+            .text(label);
+    }
+    createLabeledTableSymbol("temp-table-symbol", "tmp");
+    createLabeledTableSymbol("virtual-table-symbol", "dmv");
+    createLabeledTableSymbol("const-table-symbol", "cnst");
 }
 
 //

--- a/query-graphs/style/query-graphs.css
+++ b/query-graphs/style/query-graphs.css
@@ -49,7 +49,7 @@
 .qg-collapsed {
   stroke: hsl(0, 0%, 40%);
   stroke-width: 0.8;
-  color: hsl(0, 0%, 50%);
+  color: hsl(0, 0%, 60%);
 }
 
 /*
@@ -129,10 +129,6 @@
   color: hsl(317, 25%, 58%)
 }
 
-.qg-node-circle {
-  fill: currentColor;
-}
-
 .qg-node text {
   font-size: 9px;
   font-weight: bold;
@@ -203,6 +199,12 @@ marker#arrow {
   fill: #aaa;
 }
 
+/* Symbols */
+
+.qg-symbol-filled {
+  fill: currentColor;
+}
+
 /* Run Query */
 path.qg-run-query {
   fill: #fff;
@@ -238,6 +240,7 @@ rect.qg-table-header {
 rect.qg-table-border {
   fill: none;
 }
+
 text.qg-table-text {
   text-anchor: middle;
   font-size: 7px;


### PR DESCRIPTION
Besides some small cleanups, this series of commits primarily improves the rendering of a bunch of operator types:

* For virtualtables we now display the name of table instead of just a
  general "virtualtable". Furthermore, we now use a "dmv"-table symbol
  instead of a general "table" symbol.
* For `select`s and `earlyprobe`s, we use a new filter symbol. Not only
  for Hyper plans but also for Logical Queries.
* `tableconstruction`, i.e. tables with a contant set of tuples are now
  rendered using a "cnst" table symbol

Also the colors for collapsed nodes were slightly adjusted to have
higher contrast compared to the outline

*Before*
![before](https://user-images.githubusercontent.com/6820896/97645671-e31c0380-1a4d-11eb-8529-be17bf5fcdc4.png)

*After*
![after](https://user-images.githubusercontent.com/6820896/97645700-f0d18900-1a4d-11eb-8781-c8ad5e23a90f.png)
