### PR TITLE
bugfixes for rendering of optimizer steps

### DIFF
--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -413,7 +413,7 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         nodeUpdate
             .filter(d => {
                 return (
-                    Object.getOwnPropertyNames(getDirectProperties(d)).length || // eslint-disable-line indent
+                    Object.getOwnPropertyNames(getDirectProperties(d.data)).length || // eslint-disable-line indent
                     (d.data.hasOwnProperty("properties") && Object.getOwnPropertyNames(d.data.properties).length)
                 );
             }) // eslint-disable-line indent


### PR DESCRIPTION
**Fix crosllinks for optimizersteps**

With the new rendering of optimizersteps, the crosslinks in query plans
were broken. Note that operatorIds are only unique within an
optimizerstep and not globally

**Don't show empty tooltips**

We don't want to show empty tooltips. Still, we did so due to a bug in
our check if the tooltip would be empty...