### PR TITLE
Toolbar

### DIFF
--- a/query-graphs/src/symbols.ts
+++ b/query-graphs/src/symbols.ts
@@ -222,4 +222,98 @@ export function defineSymbols(baseSvg: SVGElement) {
     createLabeledTableSymbol("temp-table-symbol", "tmp");
     createLabeledTableSymbol("virtual-table-symbol", "dmv");
     createLabeledTableSymbol("const-table-symbol", "cnst");
+
+    // -- TOOLBAR SYMBOLS --
+    // Zoom In Symbol
+    const zoomInGroup = defs.append("g").attr("id", "zoom-in-symbol");
+    zoomInGroup
+        .append("circle")
+        .attr("class", "qg-symbol-fill-bg")
+        .attr("r", 5)
+        .attr("cx", 2)
+        .attr("cy", -2);
+    zoomInGroup
+        .append("path")
+        .attr("class", "qg-magnifier-handle")
+        .attr("d", "M-5,5 -2,2");
+    zoomInGroup
+        .append("path")
+        .attr("class", "")
+        .attr("d", "m 2,-4.5 v 5 m -2.5,-2.5 h 5");
+
+    // Zoom Out Symbol
+    const zoomOutGroup = defs.append("g").attr("id", "zoom-out-symbol");
+    zoomOutGroup
+        .append("circle")
+        .attr("class", "qg-symbol-fill-bg")
+        .attr("r", 5)
+        .attr("cx", 2)
+        .attr("cy", -2);
+    zoomOutGroup
+        .append("path")
+        .attr("class", "qg-magnifier-handle")
+        .attr("d", "M-5,5 -2,2");
+    zoomOutGroup
+        .append("path")
+        .attr("class", "")
+        .attr("d", "m -0.5,-2 h 5");
+
+    // Rotate 90 degrees left
+    const rotateLeftGroup = defs.append("g").attr("id", "rotate-left-symbol");
+    rotateLeftGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m -3.53 3.53 a 5 5 0 1 1 7.08 0");
+    rotateLeftGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m -3.25 0.80 v 2.6 h -2.6");
+
+    // Rotate 90 degrees right
+    const rotateRightGroup = defs.append("g").attr("id", "rotate-right-symbol");
+    rotateRightGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m -3.53 3.53 a 5 5 0 1 1 7.08 0");
+    rotateRightGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m 3.25 0.80 v 2.6 h 2.6");
+
+    // Recenter symbol
+    const recenterGroup = defs.append("g").attr("id", "recenter-symbol");
+    recenterGroup
+        .append("circle")
+        .attr("class", "qg-symbol-fill-fg")
+        .attr("r", 2);
+    recenterGroup
+        .append("circle")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("r", 4);
+    recenterGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m -4 0 h -3");
+    recenterGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m 4 0 h 3");
+    recenterGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m 0 -4 v -3");
+    recenterGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr("d", "m 0 4 v 3");
+
+    // Fit to screen symbol
+    const fitScreenGroup = defs.append("g").attr("id", "fit-screen-symbol");
+    fitScreenGroup
+        .append("path")
+        .attr("class", "qg-symbol-stroke-only")
+        .attr(
+            "d",
+            "m -5 -2 v -3 h 3 m 4 0 h 3 v 3 m 0 4 v 3 h -3 m -4 0 h -3 v -3 M -5 -5 l 3 3 M -5 5 l 3 -3 M 5 -5 l -3 3 M 5 5 l -3 -3",
+        );
 }

--- a/query-graphs/src/tableau.ts
+++ b/query-graphs/src/tableau.ts
@@ -481,7 +481,9 @@ function collapseNodes(root: TreeNode, graphCollapse) {
                     }
                 }
             },
-            treeDescription.allChildren,
+            function(d): TreeNode[] {
+                return d.children && d.children.length > 0 ? d.children.slice(0) : [];
+            },
         );
     }
 }

--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -1,6 +1,6 @@
 // Import local modules
 import * as treeDescription from "./tree-description";
-import {TreeDescription, Crosslink} from "./tree-description";
+import {TreeDescription, Crosslink, GraphOrientation} from "./tree-description";
 import {defineSymbols} from "./symbols";
 
 // Third-party dependencies
@@ -119,7 +119,7 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
                 return [11.2 /* table node diameter */ + 2, maxLabelLength * 6 + 10 /* textdimensionoffset */];
             },
             nodesep: (a, b) => (a.parent === b.parent ? 1 : 1.5),
-            rootx: scale => -(viewerWidth / 2 - maxLabelLength * 6) / scale,
+            rootx: scale => viewerWidth - (viewerWidth / 2 - maxLabelLength * 6) / scale,
             rooty: _scale => 0,
         },
         "bottom-to-top": {
@@ -132,7 +132,7 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
             nodesize: () => [maxLabelLength * 6, (maxLabelLength * 6) / 2],
             nodesep: (a, b) => (a.parent === b.parent ? 1 : 1),
             rootx: _scale => 0,
-            rooty: scale => -(viewerHeight / 2 - 50) / scale,
+            rooty: scale => viewerHeight - (viewerHeight / 2 - 50) / scale,
         },
         "left-to-right": {
             link: d3shape.linkHorizontal,
@@ -213,6 +213,7 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
 
     // Initialize tooltip
     const tip = d3tip()
+        .attr("id", "tooltip")
         .attr("class", "qg-tooltip")
         .offset([-10, 0])
         .html(d => {
@@ -581,11 +582,52 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         zoomBehavior.translateTo(baseSvg, x, y);
     }
 
+    // Scale the graph so that it can fit nicely on the screen
+    function fitGraphScale() {
+        // Get the bounding box of the main SVG element, we are interested in the width and height
+        const bounds = baseSvg.node().getBBox();
+        // Get the size of the container of the main SVG element
+        const parent = baseSvg.node().parentElement;
+        const fullWidth = parent.clientWidth;
+        const fullHeight = parent.clientHeight;
+        // Let's find the scale factor
+        // Thinking of only the X dimension, we need to make the width match the fullWidth, Equation:
+        //   width * xfactor = fullWidth
+        // Solving for `xfactor` we have: xfactor = fullWidth/width
+        const xfactor: number = fullWidth / bounds.width;
+        // Similarly, we would find out that: yfactor = fullHeight/height;
+        const yfactor: number = fullHeight / bounds.height;
+        // Most likely, the X and Y factor are different. We use the minimum of them to avoid cropping
+        let scaleFactor: number = Math.min(xfactor, yfactor);
+        // Add some padding so that the graph is not touching the edges
+        const paddingPercent = 0.9;
+        scaleFactor = scaleFactor * paddingPercent;
+        console.log("Scale factor", scaleFactor);
+        zoomBehavior.scaleBy(baseSvg, scaleFactor);
+    }
+
+    // Center the graph (without scaling)
+    function centerGraph() {
+        // Find the Bounding box center, then translate to it
+        // In other words, put the bbox center in the center of the screen
+        const bbox = svgGroup.node().getBBox();
+        console.log("BBox", bbox);
+        const cx = bbox.x + bbox.width / 2;
+        const cy = bbox.y + bbox.height / 2;
+        console.log("BBox center: ", cx, cy);
+        zoomBehavior.translateTo(baseSvg, cx, cy);
+    }
+
     // Scale for readability by a fixed amount due to problematic .getBBox() above
     zoomBehavior.scaleBy(baseSvg, 1.5);
 
     orientRoot();
 
+    const infoCard = d3selection
+        .select(target)
+        .append("div")
+        .attr("id", "info-card")
+        .attr("class", "qg-info-card");
     // Add metrics card
     let treeText = "";
     const properties = treeData.properties ?? {};
@@ -594,11 +636,85 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
     if (crosslinks !== undefined && crosslinks.length) {
         treeText += buildPropertyList({crosslinks: crosslinks.length});
     }
-    d3selection
-        .select(target)
+    infoCard
         .append("div")
         .classed("qg-tree-label", true)
         .html(treeText);
+
+    // Add toolbar
+    function buildToolbarButton(id: string, description: string) {
+        return `<div id='${id}-button' class='qg-toolbar-button'>
+  <span class="qg-toolbar-icon" id="zoom-in-button">
+    <svg viewbox='-8 -8 16 16' width='20px' height='20px'>
+      <use href='#${id}-symbol' class="qg-collapsed" />
+    </svg>
+  </span>
+  <span class="qg-toolbar-tooltip">${description}</span>
+</div>`;
+    }
+    // Toolbar
+    let buttonsText = "";
+    buttonsText += buildToolbarButton("zoom-in", "Zoom In");
+    buttonsText += buildToolbarButton("zoom-out", "Zoom Out");
+    buttonsText += buildToolbarButton("rotate-left", "Rotate 90° Left");
+    buttonsText += buildToolbarButton("rotate-right", "Rotate 90° Right");
+    buttonsText += buildToolbarButton("recenter", "Center root");
+    buttonsText += buildToolbarButton("fit-screen", "Fit to screen");
+    infoCard
+        .append("div")
+        .classed("qg-toolbar", true)
+        .html(buttonsText);
+
+    // Zoom toolbar buttons
+    const zoomFactor = 1.4;
+    d3selection.select("#zoom-in-button").on("click", () => {
+        zoomBehavior.scaleBy(baseSvg.transition().duration(200), zoomFactor);
+    });
+    d3selection.select("#zoom-out-button").on("click", () => {
+        zoomBehavior.scaleBy(baseSvg.transition().duration(200), 1.0 / zoomFactor);
+    });
+
+    // Rotate toolbar buttons
+    function getNewOrientation(orientation: GraphOrientation, shift: number): GraphOrientation {
+        // Gets a new orientation from a given one. 1 unit = 90 degrees
+        // Positive number: clockwise rotation
+        // Negative number: counter-clockwise rotation
+        const orientationList: GraphOrientation[] = ["top-to-bottom", "left-to-right", "bottom-to-top", "right-to-left"];
+        const index: number = orientationList.indexOf(orientation);
+        let newIndex: number = (index + shift) % 4;
+        newIndex = newIndex < 0 ? newIndex + 4 : newIndex;
+        return orientationList[newIndex];
+    }
+    function clearQueryGraph() {
+        // Removes the QueryGrpah elements. This function is useful if we want to call `drawQueryTree` again
+        // Clear the main tree
+        target.innerHTML = "";
+        // Clear the tooltip element (which is not under the main tree DOM)
+        d3selection.select("#tooltip").remove();
+    }
+    d3selection.select("#rotate-left-button").on("click", () => {
+        console.log("Rotating left...");
+        clearQueryGraph();
+        treeData.graphOrientation = getNewOrientation(graphOrientation, 1);
+        drawQueryTree(target, treeData);
+    });
+    d3selection.select("#rotate-right-button").on("click", () => {
+        console.log("Rotating right...");
+        clearQueryGraph();
+        treeData.graphOrientation = getNewOrientation(graphOrientation, -1);
+        drawQueryTree(target, treeData);
+    });
+
+    // Recenter toolbar button
+    d3selection.select("#recenter-button").on("click", () => {
+        orientRoot();
+    });
+
+    // Fit to screen button
+    d3selection.select("#fit-screen-button").on("click", () => {
+        fitGraphScale();
+        centerGraph();
+    });
 
     function expandOneLevel() {
         svgGroup.selectAll("g.qg-node").each(d => {

--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -213,7 +213,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
 
     // Initialize tooltip
     const tip = d3tip()
-        .attr("id", "tooltip")
         .attr("class", "qg-tooltip")
         .offset([-10, 0])
         .html(d => {
@@ -602,7 +601,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         // Add some padding so that the graph is not touching the edges
         const paddingPercent = 0.9;
         scaleFactor = scaleFactor * paddingPercent;
-        console.log("Scale factor", scaleFactor);
         zoomBehavior.scaleBy(baseSvg, scaleFactor);
     }
 
@@ -611,10 +609,8 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         // Find the Bounding box center, then translate to it
         // In other words, put the bbox center in the center of the screen
         const bbox = svgGroup.node().getBBox();
-        console.log("BBox", bbox);
         const cx = bbox.x + bbox.width / 2;
         const cy = bbox.y + bbox.height / 2;
-        console.log("BBox center: ", cx, cy);
         zoomBehavior.translateTo(baseSvg, cx, cy);
     }
 
@@ -626,7 +622,6 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
     const infoCard = d3selection
         .select(target)
         .append("div")
-        .attr("id", "info-card")
         .attr("class", "qg-info-card");
     // Add metrics card
     let treeText = "";
@@ -642,35 +637,25 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         .html(treeText);
 
     // Add toolbar
-    function buildToolbarButton(id: string, description: string) {
-        return `<div id='${id}-button' class='qg-toolbar-button'>
-  <span class="qg-toolbar-icon" id="zoom-in-button">
+    const toolbar = infoCard.append("div").classed("qg-toolbar", true);
+    function addToolbarButton(id: string, description: string, action : () => void) {
+        toolbar
+            .append("div")
+            .classed("qg-toolbar-button", true)
+            .on("click", action)
+            .html(`<span class="qg-toolbar-icon">
     <svg viewbox='-8 -8 16 16' width='20px' height='20px'>
       <use href='#${id}-symbol' class="qg-collapsed" />
     </svg>
   </span>
-  <span class="qg-toolbar-tooltip">${description}</span>
-</div>`;
+  <span class="qg-toolbar-tooltip">${description}</span>`);
     }
-    // Toolbar
-    let buttonsText = "";
-    buttonsText += buildToolbarButton("zoom-in", "Zoom In");
-    buttonsText += buildToolbarButton("zoom-out", "Zoom Out");
-    buttonsText += buildToolbarButton("rotate-left", "Rotate 90° Left");
-    buttonsText += buildToolbarButton("rotate-right", "Rotate 90° Right");
-    buttonsText += buildToolbarButton("recenter", "Center root");
-    buttonsText += buildToolbarButton("fit-screen", "Fit to screen");
-    infoCard
-        .append("div")
-        .classed("qg-toolbar", true)
-        .html(buttonsText);
-
     // Zoom toolbar buttons
     const zoomFactor = 1.4;
-    d3selection.select("#zoom-in-button").on("click", () => {
+    addToolbarButton("zoom-in", "Zoom In", () => {
         zoomBehavior.scaleBy(baseSvg.transition().duration(200), zoomFactor);
     });
-    d3selection.select("#zoom-out-button").on("click", () => {
+    addToolbarButton("zoom-out", "Zoom Out", () => {
         zoomBehavior.scaleBy(baseSvg.transition().duration(200), 1.0 / zoomFactor);
     });
 
@@ -686,32 +671,29 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
         return orientationList[newIndex];
     }
     function clearQueryGraph() {
-        // Removes the QueryGrpah elements. This function is useful if we want to call `drawQueryTree` again
+        // Removes the QueryGraph elements. This function is useful if we want to call `drawQueryTree` again
         // Clear the main tree
         target.innerHTML = "";
         // Clear the tooltip element (which is not under the main tree DOM)
         d3selection.select("#tooltip").remove();
     }
-    d3selection.select("#rotate-left-button").on("click", () => {
-        console.log("Rotating left...");
+    addToolbarButton("rotate-left", "Rotate 90° Left", () => {
         clearQueryGraph();
         treeData.graphOrientation = getNewOrientation(graphOrientation, 1);
         drawQueryTree(target, treeData);
     });
-    d3selection.select("#rotate-right-button").on("click", () => {
-        console.log("Rotating right...");
+    addToolbarButton("rotate-right", "Rotate 90° Right", () => {
         clearQueryGraph();
         treeData.graphOrientation = getNewOrientation(graphOrientation, -1);
         drawQueryTree(target, treeData);
     });
 
     // Recenter toolbar button
-    d3selection.select("#recenter-button").on("click", () => {
+    addToolbarButton("recenter", "Center root", () => {
         orientRoot();
     });
-
-    // Fit to screen button
-    d3selection.select("#fit-screen-button").on("click", () => {
+    // Fit to screen toolbar button
+    addToolbarButton("fit-screen", "Fit to screen", () => {
         fitGraphScale();
         centerGraph();
     });

--- a/query-graphs/src/tree-rendering.ts
+++ b/query-graphs/src/tree-rendering.ts
@@ -638,12 +638,11 @@ export function drawQueryTree(target: HTMLElement, treeData: TreeDescription) {
 
     // Add toolbar
     const toolbar = infoCard.append("div").classed("qg-toolbar", true);
-    function addToolbarButton(id: string, description: string, action : () => void) {
+    function addToolbarButton(id: string, description: string, action: () => void) {
         toolbar
             .append("div")
             .classed("qg-toolbar-button", true)
-            .on("click", action)
-            .html(`<span class="qg-toolbar-icon">
+            .on("click", action).html(`<span class="qg-toolbar-icon">
     <svg viewbox='-8 -8 16 16' width='20px' height='20px'>
       <use href='#${id}-symbol' class="qg-collapsed" />
     </svg>

--- a/query-graphs/style/query-graphs.css
+++ b/query-graphs/style/query-graphs.css
@@ -20,7 +20,7 @@
   font-size: 13px;
   font-weight: bold;
   font-family: Monaco, Consolas, monospace;
-  padding: 12px;
+  padding: 12px 12px 0 12px;
 }
 
 .qg-toolbar {
@@ -31,11 +31,13 @@
 
 .qg-toolbar-button {
   position: relative;
-  display: inline-grid;
+  display: inline-block;
+  vertical-align: bottom;
   border: thin solid hsl(0 0% 60%);
   border-width: 1px 1px 1px 0;
   padding: 3px;
   font-family: Monaco, Consolas, monospace;
+  user-select: none;
 }
 
 .qg-toolbar-button:hover {

--- a/query-graphs/style/query-graphs.css
+++ b/query-graphs/style/query-graphs.css
@@ -6,19 +6,77 @@
   margin: 0 auto;
 }
 
-.qg-tree-label {
-  margin: 0 auto;
+.qg-info-card {
   position: absolute;
   top: 3px;
   right: 3px;
+  background-color: rgba(255, 255, 255, 0.85);
+  border: thin solid #ccc;
+  border-radius: 5px;
+  box-shadow: 2px 2px 2px #888;
+}
+
+.qg-tree-label {
   font-size: 13px;
   font-weight: bold;
   font-family: Monaco, Consolas, monospace;
-  background-color: rgba(255, 255, 255, 0.85);
   padding: 12px;
-  border: thin solid #eee;
+}
+
+.qg-toolbar {
+  float: right;
+  display: inline-block;
+  padding: 2px;
+}
+
+.qg-toolbar-button {
+  position: relative;
+  display: inline-grid;
+  border: thin solid hsl(0 0% 60%);
+  border-width: 1px 1px 1px 0;
+  padding: 3px;
+  font-family: Monaco, Consolas, monospace;
+}
+
+.qg-toolbar-button:hover {
+  background: #eee;
+  cursor: pointer;
+}
+
+.qg-toolbar-button:first-child {
+  border-width: 1px;
+}
+
+.qg-toolbar-tooltip {
+  visibility: hidden;
+  text-align: center;
   border-radius: 5px;
-  box-shadow: 2px 2px 2px #888;
+  padding: 8px;
+  position: absolute;
+  z-index: 1;
+  top: 150%;
+  right: 0;
+  width: 125px;
+  background: #ccc;
+  font-size: 11px;
+}
+
+.qg-toolbar-tooltip::after {
+  content: " ";
+  top: -10px;
+  right: 8px;
+  border-color: transparent transparent #ccc transparent;
+  border-width: 5px;
+  position: absolute;
+  border-style: solid;
+}
+
+.qg-toolbar-icon > svg {
+  display: block;
+}
+
+.qg-toolbar-button:hover .qg-toolbar-tooltip {
+  visibility: visible;
 }
 
 .qg-node {
@@ -213,6 +271,11 @@ marker#arrow {
   stroke: none;
 }
 
+.qg-symbol-stroke-only {
+  stroke-width: 1.2;
+  fill: none;
+}
+
 /* Run Query */
 path.qg-run-query {
   fill: #fff;
@@ -252,4 +315,9 @@ text.qg-table-text {
   font-family: Monaco, Consolas, monospace;
   stroke: none;
   fill: hsl(0, 0%, 40%);
+}
+
+.qg-magnifier-handle {
+  stroke-width: 1.5;
+  stroke-linecap: round;
 }

--- a/standalone-server/legend.ts
+++ b/standalone-server/legend.ts
@@ -14,6 +14,12 @@ const symbols = [
     {name: "Const Table", symbol: "const-table-symbol"},
     {name: "Virtual Table", symbol: "virtual-table-symbol"},
     {name: "Temp Table", symbol: "temp-table-symbol"},
+    {name: "Zoom In", symbol: "zoom-in-symbol"},
+    {name: "Zoom Out", symbol: "zoom-out-symbol"},
+    {name: "Rotate Left", symbol: "rotate-left-symbol"},
+    {name: "Rotate Right", symbol: "rotate-right-symbol"},
+    {name: "Recenter", symbol: "recenter-symbol"},
+    {name: "Fit to screen", symbol: "fit-screen-symbol"},
 ];
 
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Added toolbar:
- Toolbar icons: 6 new icons.
- Toolbar graphics. The toolbar is included on the top-right card. It displays the 6 icons and has some hover effects (including a tooltip describing what the button does)
- Toolbar functionality. Some old functionality was just mapped to a button, but there is new functionality too.
  - Zoom in
  - Zoom out
  - Rotate left. Most functionality was already present. Rotation basically triggers a refresh.
  - Rotate right
  - Center root.
  - Fit to screen. New! All of the graph can be viewed at once. Centered and zoomed so that everything is visible.
- Corresponding CSS style changes

Also, I saw and fixed a couple of bugs:
- Orientations right-to-left and bottom-to-top had the incorrect initial coordinates (fix was on "orientations" rootx/rooty functions
- Tableau loader streamline collapse was not working correctly. I restored an old function in `tableau.ts` function `collapseNodes`. 

<img width="801" alt="Screen Shot 2020-11-06 at 3 36 25 PM" src="https://user-images.githubusercontent.com/1087437/98427366-b79ea780-2051-11eb-92d9-cf05e38e86ee.png">
