### PR TITLE
Fix Visualization URL bug. Generate full URL

### DIFF
--- a/standalone-server/upload-server.js
+++ b/standalone-server/upload-server.js
@@ -97,14 +97,14 @@ function deleteOldFiles() {
     });
 }
 
-function getVisualizationURL(filePath) {
-    return "/query-graphs.html?file=" + encodeURIComponent(path.relative(WEBROOT_DIR, filePath));
+function getVisualizationURL(req, filePath) {
+    return "http://" + req.get("host") + "/query-graphs.html?file=" + encodeURIComponent(path.relative(WEBROOT_DIR, filePath));
 }
 
 app.post("/file-upload", upload.single("queryfile"), function(req, res, _next) {
     console.log("/file-upload called");
     deleteOldFiles();
-    const visualizationUrl = getVisualizationURL(path.join(UPLOAD_DIR, req.file.filename));
+    const visualizationUrl = getVisualizationURL(req, path.join(UPLOAD_DIR, req.file.filename));
     console.log(req.body);
     if (req.body && req.body.redirect && req.body.redirect === "yes") {
         // Redirect to the Visualization URL
@@ -123,7 +123,7 @@ app.post("/text-upload", function(req, res) {
     fs.writeFileSync(filename, querytext);
     deleteOldFiles();
     // Redirect to the Visualization URL
-    res.redirect(getVisualizationURL(filename));
+    res.redirect(getVisualizationURL(req, filename));
 });
 
 function escapeHtml(unsafe) {
@@ -160,7 +160,7 @@ app.get("/favorites", function(req, res) {
             for (let j = commonLen; j < relPath.length; ++j) {
                 html += "<li>" + escapeHtml(relPath[j]) + "<ul>";
             }
-            html += "<li><a href='" + escapeHtml(getVisualizationURL(name)) + "'>" + escapeHtml(fileName) + "</a></li>";
+            html += "<li><a href='" + escapeHtml(getVisualizationURL(req, name)) + "'>" + escapeHtml(fileName) + "</a></li>";
             lastPath = relPath;
         });
         html += "</ul></body></html>";


### PR DESCRIPTION
After updating QueryGraphs, TLV wouldn't be able to use the "Use external visualizer service". File upload would succeed, but then the browser wouldn't open and display the visualization.The problem was that TLV expects QueryGraphs service to reply with the full URL where the visualization can be found; but it was replying with only a relative path.

I tracked the regression to this change
https://github.com/tableau/query-graphs/commit/4cc918243aff46c2317fcaa78379052193fbe74c#diff-cf6abcbb1a404da0b5823b23628a687e614f3b9c44e65ed40dfb3c669990f6b1L100

Testing done: tested the 3 places where `getVisualizationURL` is used:
1) `file-upload` funcionality
  a) TLV visualize query button
  b) Upload form, direct file upload
2) `text-upload`. Upload form, copy & paste upload
3) URLs in `/favorites`