### PR TITLE
No longer display the file name in the info card by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ Current visualizations are tailored for artifacts from Tableau's query ecosystem
 LogicalQuery XML, QueryFunction XML, and Hyper query-plan JSON.
 Postgres EXPLAIN (FORMAT JSON) is also supported.
 
-You can view example query visualizations online:
-* <https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/tableau/joins.xml>,
-* <https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/tableau/query-function.xml&collapse=n>,
-* <https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/tableau/dint4.xml>,
-* <https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/hyper/tpch-q1.plan.json>,
-* <https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/hyper/tpch-q2-steps.plan.json&orientation=left-to-right>, or
-* <https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/postgres/ctescan.json>
+You can view a few example query visualizations online:
+* [Tableau Logical Query joining 3 tables](https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/tableau/joins.xml&properties={"title":"Tableau%20Logical%20Query"}),
+* [Federated query](https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/tableau/dint4.xml&properties={"title":"Federated%20Query"}),
+* [Hyper query plan for TPC-H Q1](https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/hyper/tpch-q1.plan.json&properties={"title":"TPC-H%20Q1%20in%20Hyper"}),
+* [Optimizer steps of Hyper for TPC-H Q2](https://tableau.github.io/query-graphs/query-graphs.html?file=favorites/hyper/tpch-q2-steps.plan.json&orientation=left-to-right&properties={"title":"Optimizer%20steps%20for%20TPC-H%20Q2"}),
 
 Installation
 ------------

--- a/query-graphs/src/hyper.ts
+++ b/query-graphs/src/hyper.ts
@@ -79,7 +79,7 @@ function convertHyperNode(node: Json, parentKey = "result"): TreeNode | TreeNode
         }
 
         // Display these properties always as properties, even if they are more complex
-        const propertyKeys = ["analyze"];
+        const propertyKeys = ["analyze", "querylocs"];
         for (const key of propertyKeys) {
             if (!node.hasOwnProperty(key)) {
                 continue;

--- a/standalone-server/app.ts
+++ b/standalone-server/app.ts
@@ -35,14 +35,7 @@ const searchParams = new URLSearchParams(currentSearch);
 const DEBUG = searchParams.has("debug");
 
 // Get file path
-let graphFile = searchParams.get("file") ?? "favorites/logicalquery.xml";
-
-// Get inline graph string
-let inlineString;
-if (searchParams.has("inline")) {
-    inlineString = searchParams.get("inline");
-    graphFile = "";
-}
+const graphFile = searchParams.get("file") ?? "favorites/logicalquery.xml";
 
 // Get file format
 const fileFormat = searchParams.get("format");
@@ -188,19 +181,15 @@ if (paramErrors.length) {
             document.write(errors.reduce((a, b) => a + "<br/>" + b));
         }
     };
-    if (inlineString) {
-        displayTree(inlineString);
-    } else {
-        fetch(graphFile)
-            .then(response => {
-                if (!response.ok)
-                    throw new Error(
-                        "Request for '" + graphFile + "' failed with '" + response.status + " " + response.statusText + "'.",
-                    );
-                return response.text();
-            })
-            .then(displayTree, err => {
-                document.write(err);
-            });
-    }
+    fetch(graphFile)
+        .then(response => {
+            if (!response.ok)
+                throw new Error(
+                    "Request for '" + graphFile + "' failed with '" + response.status + " " + response.statusText + "'.",
+                );
+            return response.text();
+        })
+        .then(displayTree, err => {
+            document.write(err);
+        });
 }

--- a/standalone-server/app.ts
+++ b/standalone-server/app.ts
@@ -90,11 +90,6 @@ if (propertiesParam !== null) {
     }
 }
 
-// Add the file name to the displayed properties
-if (!inlineString) {
-    toplevelProperties.set("file", graphFile);
-}
-
 const delay = (function() {
     let timer = 0;
     return (callback: CallableFunction, ms: number) => {

--- a/standalone-server/upload-server.js
+++ b/standalone-server/upload-server.js
@@ -98,7 +98,9 @@ function deleteOldFiles() {
 }
 
 function getVisualizationURL(req, filePath) {
-    return "http://" + req.get("host") + "/query-graphs.html?file=" + encodeURIComponent(path.relative(WEBROOT_DIR, filePath));
+    const relpath = path.relative(WEBROOT_DIR, filePath);
+    const properties = encodeURIComponent(JSON.stringify({file: relpath}));
+    return "http://" + req.get("host") + "/query-graphs.html?file=" + encodeURIComponent(relpath) + "&properties=" + properties;
 }
 
 app.post("/file-upload", upload.single("queryfile"), function(req, res, _next) {

--- a/standalone-server/webroot/favorites/hyper/cte.plan.json
+++ b/standalone-server/webroot/favorites/hyper/cte.plan.json
@@ -21,6 +21,7 @@
         "cardinality": 3,
         "input": {
           "operator": "tableconstruction",
+          "querylocs": [[30, 39]],
           "operatorId": 5,
           "cardinality": 3,
           "output": [["v3", ["Integer"]]],

--- a/standalone-server/webroot/favorites/hyper/groupby.plan.json
+++ b/standalone-server/webroot/favorites/hyper/groupby.plan.json
@@ -11,6 +11,7 @@
     "cardinality": 100,
     "input": {
       "operator": "tablescan",
+      "querylocs": [[51, 53]],
       "operatorId": 3,
       "cardinality": 2000,
       "relationId": 0,
@@ -21,6 +22,6 @@
     },
     "behavior": "regular",
     "values": [{"value": {"expression": "iuref", "iu": "v4"}}, {"value": {"expression": "iuref", "iu": "v5"}}, {"value": {"expression": "iuref", "iu": "v6"}}],
-    "aggregates": [{"source": 0, "operation": {"aggregate": "keep"}, "iu": ["v", ["Integer"]]}, {"source": 2, "operation": {"aggregate": "avg"}, "iu": ["v3", ["Numeric", 14, 4]]}, {"source": 1, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigInt"]]}]
+    "aggregates": [{"source": 2, "operation": {"aggregate": "avg"}, "iu": ["v3", ["Numeric", 14, 4]]}, {"source": 1, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigInt"]]}, {"source": 0, "operation": {"aggregate": "keep"}, "iu": ["v", ["Integer"]]}]
   }
 }

--- a/standalone-server/webroot/favorites/hyper/insert.plan.json
+++ b/standalone-server/webroot/favorites/hyper/insert.plan.json
@@ -24,6 +24,7 @@
         "method": "bnl",
         "left": {
           "operator": "tableconstruction",
+          "querylocs": [[67, 76]],
           "operatorId": 5,
           "cardinality": 2,
           "output": [["v7", ["Integer"]]],
@@ -31,6 +32,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[62, 64]],
           "operatorId": 6,
           "cardinality": 2000,
           "relationId": 0,

--- a/standalone-server/webroot/favorites/hyper/magicunnesting.plan.json
+++ b/standalone-server/webroot/favorites/hyper/magicunnesting.plan.json
@@ -12,6 +12,7 @@
     "method": "hash",
     "left": {
       "operator": "tablescan",
+      "querylocs": [[73, 75]],
       "operatorId": 3,
       "cardinality": 2000,
       "relationId": 0,
@@ -45,6 +46,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[50, 52]],
           "operatorId": 8,
           "cardinality": 2000,
           "relationId": 1,

--- a/standalone-server/webroot/favorites/hyper/markjoin.plan.json
+++ b/standalone-server/webroot/favorites/hyper/markjoin.plan.json
@@ -12,6 +12,7 @@
     "method": "hash",
     "left": {
       "operator": "tablescan",
+      "querylocs": [[85, 87]],
       "operatorId": 3,
       "cardinality": 2000,
       "relationId": 0,
@@ -22,6 +23,7 @@
     },
     "right": {
       "operator": "tablescan",
+      "querylocs": [[50, 52]],
       "operatorId": 4,
       "cardinality": 2000,
       "relationId": 1,

--- a/standalone-server/webroot/favorites/hyper/tableconstruction.plan.json
+++ b/standalone-server/webroot/favorites/hyper/tableconstruction.plan.json
@@ -7,6 +7,7 @@
   "outputNames": ["1", "2"],
   "input": {
     "operator": "tableconstruction",
+    "querylocs": [[18, 34]],
     "operatorId": 2,
     "cardinality": 2,
     "output": [["v", ["Varchar"]], ["v2", ["Varchar"]]],

--- a/standalone-server/webroot/favorites/hyper/tablefunction.plan.json
+++ b/standalone-server/webroot/favorites/hyper/tablefunction.plan.json
@@ -7,6 +7,7 @@
   "outputNames": ["generate_series"],
   "input": {
     "operator": "tablefunction",
+    "querylocs": [[32, 47]],
     "operatorId": 2,
     "cardinality": 10,
     "input": {

--- a/standalone-server/webroot/favorites/hyper/tablescan.plan.json
+++ b/standalone-server/webroot/favorites/hyper/tablescan.plan.json
@@ -7,6 +7,7 @@
   "outputNames": ["r_name"],
   "input": {
     "operator": "tablescan",
+    "querylocs": [[37, 43]],
     "operatorId": 2,
     "cardinality": 5,
     "relationId": 9,

--- a/standalone-server/webroot/favorites/hyper/tpch-q1.plan.json
+++ b/standalone-server/webroot/favorites/hyper/tpch-q1.plan.json
@@ -16,6 +16,7 @@
       "cardinality": 6,
       "input": {
         "operator": "tablescan",
+        "querylocs": [[561, 569]],
         "operatorId": 4,
         "cardinality": 568,
         "relationId": 7,

--- a/standalone-server/webroot/favorites/hyper/tpch-q2-steps.plan.json
+++ b/standalone-server/webroot/favorites/hyper/tpch-q2-steps.plan.json
@@ -34,6 +34,7 @@
                   "operatorId": 9,
                   "left": {
                     "operator": "tablescan",
+                    "querylocs": [[297, 301]],
                     "operatorId": 10,
                     "relationId": 2,
                     "schema": {"type":"sessionschema"},
@@ -46,6 +47,7 @@
                   },
                   "right": {
                     "operator": "tablescan",
+                    "querylocs": [[311, 319]],
                     "operatorId": 11,
                     "relationId": 3,
                     "schema": {"type":"sessionschema"},
@@ -60,6 +62,7 @@
                 },
                 "right": {
                   "operator": "tablescan",
+                  "querylocs": [[329, 337]],
                   "operatorId": 12,
                   "relationId": 4,
                   "schema": {"type":"sessionschema"},
@@ -74,6 +77,7 @@
               },
               "right": {
                 "operator": "tablescan",
+                "querylocs": [[347, 353]],
                 "operatorId": 13,
                 "relationId": 8,
                 "schema": {"type":"sessionschema"},
@@ -88,6 +92,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[363, 369]],
               "operatorId": 14,
               "relationId": 9,
               "schema": {"type":"sessionschema"},
@@ -120,6 +125,7 @@
                       "operatorId": 20,
                       "left": {
                         "operator": "tablescan",
+                        "querylocs": [[746, 754]],
                         "operatorId": 21,
                         "relationId": 4,
                         "schema": {"type":"sessionschema"},
@@ -132,6 +138,7 @@
                       },
                       "right": {
                         "operator": "tablescan",
+                        "querylocs": [[780, 788]],
                         "operatorId": 22,
                         "relationId": 3,
                         "schema": {"type":"sessionschema"},
@@ -146,6 +153,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[814, 820]],
                       "operatorId": 23,
                       "relationId": 8,
                       "schema": {"type":"sessionschema"},
@@ -160,6 +168,7 @@
                   },
                   "right": {
                     "operator": "tablescan",
+                    "querylocs": [[846, 852]],
                     "operatorId": 24,
                     "relationId": 9,
                     "schema": {"type":"sessionschema"},
@@ -221,6 +230,7 @@
                 "operatorId": 8,
                 "left": {
                   "operator": "tablescan",
+                  "querylocs": [[297, 301]],
                   "operatorId": 9,
                   "relationId": 2,
                   "schema": {"type":"sessionschema"},
@@ -230,6 +240,7 @@
                 },
                 "right": {
                   "operator": "tablescan",
+                  "querylocs": [[311, 319]],
                   "operatorId": 10,
                   "relationId": 3,
                   "schema": {"type":"sessionschema"},
@@ -241,6 +252,7 @@
               },
               "right": {
                 "operator": "tablescan",
+                "querylocs": [[329, 337]],
                 "operatorId": 11,
                 "relationId": 4,
                 "schema": {"type":"sessionschema"},
@@ -252,6 +264,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[347, 353]],
               "operatorId": 12,
               "relationId": 8,
               "schema": {"type":"sessionschema"},
@@ -263,6 +276,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[363, 369]],
             "operatorId": 13,
             "relationId": 9,
             "schema": {"type":"sessionschema"},
@@ -289,6 +303,7 @@
                   "operatorId": 18,
                   "left": {
                     "operator": "tablescan",
+                    "querylocs": [[746, 754]],
                     "operatorId": 19,
                     "relationId": 4,
                     "schema": {"type":"sessionschema"},
@@ -298,6 +313,7 @@
                   },
                   "right": {
                     "operator": "tablescan",
+                    "querylocs": [[780, 788]],
                     "operatorId": 20,
                     "relationId": 3,
                     "schema": {"type":"sessionschema"},
@@ -309,6 +325,7 @@
                 },
                 "right": {
                   "operator": "tablescan",
+                  "querylocs": [[814, 820]],
                   "operatorId": 21,
                   "relationId": 8,
                   "schema": {"type":"sessionschema"},
@@ -320,6 +337,7 @@
               },
               "right": {
                 "operator": "tablescan",
+                "querylocs": [[846, 852]],
                 "operatorId": 22,
                 "relationId": 9,
                 "schema": {"type":"sessionschema"},
@@ -380,6 +398,7 @@
                     "operatorId": 10,
                     "left": {
                       "operator": "tablescan",
+                      "querylocs": [[846, 852]],
                       "operatorId": 11,
                       "relationId": 9,
                       "schema": {"type":"sessionschema"},
@@ -390,6 +409,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[814, 820]],
                       "operatorId": 12,
                       "relationId": 8,
                       "schema": {"type":"sessionschema"},
@@ -401,6 +421,7 @@
                   },
                   "right": {
                     "operator": "tablescan",
+                    "querylocs": [[780, 788]],
                     "operatorId": 13,
                     "relationId": 3,
                     "schema": {"type":"sessionschema"},
@@ -412,6 +433,7 @@
                 },
                 "right": {
                   "operator": "tablescan",
+                  "querylocs": [[746, 754]],
                   "operatorId": 14,
                   "relationId": 4,
                   "schema": {"type":"sessionschema"},
@@ -427,6 +449,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[297, 301]],
               "operatorId": 15,
               "relationId": 2,
               "schema": {"type":"sessionschema"},
@@ -439,6 +462,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[329, 337]],
             "operatorId": 16,
             "relationId": 4,
             "schema": {"type":"sessionschema"},
@@ -453,6 +477,7 @@
           "operatorId": 17,
           "left": {
             "operator": "tablescan",
+            "querylocs": [[347, 353]],
             "operatorId": 18,
             "relationId": 8,
             "schema": {"type":"sessionschema"},
@@ -462,6 +487,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[311, 319]],
             "operatorId": 19,
             "relationId": 3,
             "schema": {"type":"sessionschema"},
@@ -475,6 +501,7 @@
       },
       "right": {
         "operator": "tablescan",
+        "querylocs": [[363, 369]],
         "operatorId": 20,
         "relationId": 9,
         "schema": {"type":"sessionschema"},
@@ -506,6 +533,7 @@
       "cardinality": 1,
       "left": {
         "operator": "tablescan",
+        "querylocs": [[363, 369]],
         "operatorId": 4,
         "cardinality": 1,
         "relationId": 9,
@@ -533,6 +561,7 @@
               "cardinality": 6,
               "left": {
                 "operator": "tablescan",
+                "querylocs": [[297, 301]],
                 "operatorId": 9,
                 "cardinality": 6,
                 "relationId": 2,
@@ -560,6 +589,7 @@
                       "cardinality": 5,
                       "left": {
                         "operator": "tablescan",
+                        "querylocs": [[846, 852]],
                         "operatorId": 14,
                         "cardinality": 1,
                         "relationId": 9,
@@ -571,6 +601,7 @@
                       },
                       "right": {
                         "operator": "tablescan",
+                        "querylocs": [[814, 820]],
                         "operatorId": 15,
                         "cardinality": 25,
                         "relationId": 8,
@@ -583,6 +614,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[780, 788]],
                       "operatorId": 16,
                       "cardinality": 518,
                       "relationId": 3,
@@ -595,6 +627,7 @@
                   },
                   "right": {
                     "operator": "tablescan",
+                    "querylocs": [[746, 754]],
                     "operatorId": 17,
                     "cardinality": 537,
                     "relationId": 4,
@@ -613,6 +646,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[329, 337]],
               "operatorId": 18,
               "cardinality": 537,
               "relationId": 4,
@@ -625,6 +659,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[311, 319]],
             "operatorId": 19,
             "cardinality": 518,
             "relationId": 3,
@@ -637,6 +672,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[347, 353]],
           "operatorId": 20,
           "cardinality": 25,
           "relationId": 8,
@@ -671,6 +707,7 @@
       "method": "hash",
       "left": {
         "operator": "tablescan",
+        "querylocs": [[363, 369]],
         "operatorId": 4,
         "cardinality": 1,
         "relationId": 9,
@@ -702,6 +739,7 @@
               "method": "hash",
               "left": {
                 "operator": "tablescan",
+                "querylocs": [[297, 301]],
                 "operatorId": 9,
                 "cardinality": 6,
                 "relationId": 2,
@@ -732,6 +770,7 @@
                       "method": "hash",
                       "left": {
                         "operator": "tablescan",
+                        "querylocs": [[846, 852]],
                         "operatorId": 14,
                         "cardinality": 1,
                         "relationId": 9,
@@ -743,6 +782,7 @@
                       },
                       "right": {
                         "operator": "tablescan",
+                        "querylocs": [[814, 820]],
                         "operatorId": 15,
                         "cardinality": 25,
                         "relationId": 8,
@@ -755,6 +795,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[780, 788]],
                       "operatorId": 16,
                       "cardinality": 518,
                       "relationId": 3,
@@ -770,6 +811,7 @@
                     "operatorId": 17,
                     "input": {
                       "operator": "tablescan",
+                      "querylocs": [[746, 754]],
                       "operatorId": 18,
                       "cardinality": 537,
                       "relationId": 4,
@@ -791,6 +833,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[329, 337]],
               "operatorId": 19,
               "cardinality": 537,
               "relationId": 4,
@@ -803,6 +846,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[311, 319]],
             "operatorId": 20,
             "cardinality": 518,
             "relationId": 3,
@@ -815,6 +859,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[347, 353]],
           "operatorId": 21,
           "cardinality": 25,
           "relationId": 8,
@@ -849,6 +894,7 @@
       "method": "hash",
       "left": {
         "operator": "tablescan",
+        "querylocs": [[363, 369]],
         "operatorId": 4,
         "cardinality": 1,
         "relationId": 9,
@@ -880,6 +926,7 @@
               "method": "hash",
               "left": {
                 "operator": "tablescan",
+                "querylocs": [[297, 301]],
                 "operatorId": 9,
                 "cardinality": 6,
                 "relationId": 2,
@@ -910,6 +957,7 @@
                       "method": "hash",
                       "left": {
                         "operator": "tablescan",
+                        "querylocs": [[846, 852]],
                         "operatorId": 14,
                         "cardinality": 1,
                         "relationId": 9,
@@ -921,6 +969,7 @@
                       },
                       "right": {
                         "operator": "tablescan",
+                        "querylocs": [[814, 820]],
                         "operatorId": 15,
                         "cardinality": 25,
                         "relationId": 8,
@@ -933,6 +982,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[780, 788]],
                       "operatorId": 16,
                       "cardinality": 518,
                       "relationId": 3,
@@ -948,6 +998,7 @@
                     "operatorId": 17,
                     "input": {
                       "operator": "tablescan",
+                      "querylocs": [[746, 754]],
                       "operatorId": 18,
                       "cardinality": 537,
                       "relationId": 4,
@@ -969,6 +1020,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[329, 337]],
               "operatorId": 19,
               "cardinality": 537,
               "relationId": 4,
@@ -981,6 +1033,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[311, 319]],
             "operatorId": 20,
             "cardinality": 518,
             "relationId": 3,
@@ -993,6 +1046,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[347, 353]],
           "operatorId": 21,
           "cardinality": 25,
           "relationId": 8,
@@ -1029,6 +1083,7 @@
       "method": "hash",
       "left": {
         "operator": "tablescan",
+        "querylocs": [[363, 369]],
         "operatorId": 4,
         "cardinality": 1,
         "relationId": 9,
@@ -1060,6 +1115,7 @@
               "method": "hash",
               "left": {
                 "operator": "tablescan",
+                "querylocs": [[297, 301]],
                 "operatorId": 9,
                 "cardinality": 6,
                 "relationId": 2,
@@ -1090,6 +1146,7 @@
                       "method": "hash",
                       "left": {
                         "operator": "tablescan",
+                        "querylocs": [[846, 852]],
                         "operatorId": 14,
                         "cardinality": 1,
                         "relationId": 9,
@@ -1101,6 +1158,7 @@
                       },
                       "right": {
                         "operator": "tablescan",
+                        "querylocs": [[814, 820]],
                         "operatorId": 15,
                         "cardinality": 25,
                         "relationId": 8,
@@ -1113,6 +1171,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[780, 788]],
                       "operatorId": 16,
                       "cardinality": 518,
                       "relationId": 3,
@@ -1128,6 +1187,7 @@
                     "operatorId": 17,
                     "input": {
                       "operator": "tablescan",
+                      "querylocs": [[746, 754]],
                       "operatorId": 18,
                       "cardinality": 537,
                       "relationId": 4,
@@ -1149,6 +1209,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[329, 337]],
               "operatorId": 19,
               "cardinality": 537,
               "relationId": 4,
@@ -1161,6 +1222,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[311, 319]],
             "operatorId": 20,
             "cardinality": 518,
             "relationId": 3,
@@ -1173,6 +1235,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[347, 353]],
           "operatorId": 21,
           "cardinality": 25,
           "relationId": 8,

--- a/standalone-server/webroot/favorites/hyper/tpch-q2.plan.json
+++ b/standalone-server/webroot/favorites/hyper/tpch-q2.plan.json
@@ -18,6 +18,7 @@
       "method": "hash",
       "left": {
         "operator": "tablescan",
+        "querylocs": [[347, 353]],
         "operatorId": 4,
         "cardinality": 1,
         "relationId": 9,
@@ -49,6 +50,7 @@
               "method": "hash",
               "left": {
                 "operator": "tablescan",
+                "querylocs": [[281, 285]],
                 "operatorId": 9,
                 "cardinality": 6,
                 "relationId": 2,
@@ -79,6 +81,7 @@
                       "method": "hash",
                       "left": {
                         "operator": "tablescan",
+                        "querylocs": [[830, 836]],
                         "operatorId": 14,
                         "cardinality": 1,
                         "relationId": 9,
@@ -90,6 +93,7 @@
                       },
                       "right": {
                         "operator": "tablescan",
+                        "querylocs": [[798, 804]],
                         "operatorId": 15,
                         "cardinality": 25,
                         "relationId": 8,
@@ -102,6 +106,7 @@
                     },
                     "right": {
                       "operator": "tablescan",
+                      "querylocs": [[764, 772]],
                       "operatorId": 16,
                       "cardinality": 518,
                       "relationId": 3,
@@ -117,6 +122,7 @@
                     "operatorId": 17,
                     "input": {
                       "operator": "tablescan",
+                      "querylocs": [[730, 738]],
                       "operatorId": 18,
                       "cardinality": 537,
                       "relationId": 4,
@@ -138,6 +144,7 @@
             },
             "right": {
               "operator": "tablescan",
+              "querylocs": [[313, 321]],
               "operatorId": 19,
               "cardinality": 537,
               "relationId": 4,
@@ -150,6 +157,7 @@
           },
           "right": {
             "operator": "tablescan",
+            "querylocs": [[295, 303]],
             "operatorId": 20,
             "cardinality": 518,
             "relationId": 3,
@@ -162,6 +170,7 @@
         },
         "right": {
           "operator": "tablescan",
+          "querylocs": [[331, 337]],
           "operatorId": 21,
           "cardinality": 25,
           "relationId": 8,

--- a/standalone-server/webroot/favorites/hyper/window.plan.json
+++ b/standalone-server/webroot/favorites/hyper/window.plan.json
@@ -15,6 +15,7 @@
       "cardinality": 2000,
       "input": {
         "operator": "tablescan",
+        "querylocs": [[139, 141]],
         "operatorId": 4,
         "cardinality": 2000,
         "relationId": 0,


### PR DESCRIPTION
You can point the `file` parameter to arbitrary URLs, including `data:`-URLs or, e.g., S3-URLs. Displaying the full, potentially really long URL makes this pretty unreadable, though.

Hence, this series of commits adjusts the frontend Javascript code such that the URL is no longer displayed by default. Instead, one can provide the intended meta-data through the `properties` parameter.
At the same time, we modify the backend code, to provide the file-path as part of the `properties` parameter.

Thereby, all in all, things stays as they are from a user-point of view, but I can send hand-crafted URLs to colleagues which, e.g., display a query-plan directly downloaded from S3