### PR TITLE
Hyper: Properly render parquet scan & update tablescan names for recent changes to plan JSON format

### DIFF
--- a/standalone-app/examples/hyper/cte.plan.json
+++ b/standalone-app/examples/hyper/cte.plan.json
@@ -15,7 +15,7 @@
       "operatorId": 3,
       "cardinality": 3,
       "output": [{"source": {"expression": "iuref", "iu": ["v3", ["Integer"]]}, "target": ["v2", ["Integer"]]}],
-      "source": {
+      "input": {
         "operator": "temp",
         "operatorId": 4,
         "cardinality": 3,
@@ -34,7 +34,7 @@
       "operatorId": 6,
       "cardinality": 3,
       "output": [{"source": {"expression": "iuref", "iu": "v3"}, "target": ["v", ["Integer"]]}],
-      "source": 4
+      "input": 4
     },
     "condition": {"expression": "const", "value": {"type": ["Bool"], "value": true}}
   }

--- a/standalone-app/examples/hyper/magicunnesting.plan.json
+++ b/standalone-app/examples/hyper/magicunnesting.plan.json
@@ -35,7 +35,7 @@
           "operatorId": 6,
           "cardinality": 100,
           "output": [{"source": {"expression": "iuref", "iu": ["v3", ["Integer"]]}, "target": ["v4", ["Integer"]]}],
-          "source": {
+          "input": {
             "operator": "groupby",
             "operatorId": 7,
             "cardinality": 100,


### PR DESCRIPTION
Table scans and Parquet scans nowadays use the `debugName` instead of the `name` property
to store the table name. With this commit we now render the `debugName` correctly to label
the scans in the tree.

Furthermore, Parquet scans (and all other external format scans) have a `source` property.
This `source` property is structured, and hence rendered as nodes in the tree. However,
we had special logic to render `source` properties as non-collapsed by default. Hence,
the `source` properties were cluttering the structure of the query graph. With this change,
`source` properties are now rendered as collaped by default. The special treatment of `source`
was previously necessary to correctly render `explicitscan` operators which stored their
input tree in the `source` property. In a recent commit, I adjusted Hyper to use the `input`
property instead for `explicitscan`s.

Last but not least, we now use the table scan icon for Parquet scans.

----

**Before**
<img width="946" alt="before" src="https://user-images.githubusercontent.com/6820896/167043265-acd33473-ce30-4986-8f0e-981326a157b1.png">

**After**
<img width="467" alt="after" src="https://user-images.githubusercontent.com/6820896/167043277-429fdf75-15de-4ffb-9ed1-c0fa75ead1bf.png">
