### PR TITLE
Hyper: Fix crosslinks for `explicitscan` & sort properties alphabetically

### DIFF
--- a/query-graphs/src/loader-utils.ts
+++ b/query-graphs/src/loader-utils.ts
@@ -1,7 +1,7 @@
 // Stricter type for JSON data
 type JsonPrimitive = string | number | boolean | null;
 export type Json = JsonPrimitive | JsonObject | JsonArray;
-interface JsonObject {
+export interface JsonObject {
     [x: string]: JsonPrimitive | JsonObject | JsonArray;
 }
 type JsonArray = Array<Json>;


### PR DESCRIPTION
This commit contains multiple inter-related changes:
1. The properties/subtrees of a node are now ordered alphabetically,
   with a couple of special cased names, such that "left" is always
   before "right" (alphabetical order takes care of this anyway,
   but better code this explicitly than implicitly)
2. Like all other keys, also the special-cased keys `input`, `left`,
   etc. are now adaptively displayed, i.e. scalar values are
   displayed in the properties card instead of as part of the tree.
3. Crosslinks for explicitscans are updated to work for newer versions
   of Hyper, which use `input` instead of `source` to refer to the
   input operator.