### PR TITLE
Allow node prop values to be selected

### DIFF
--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -89,3 +89,10 @@
 .qg-prop-name {
     color: hsl(0, 0%, 50%);
 }
+
+.qg-prop-value {
+    -webkit-user-select: all;  
+    -moz-user-select: all;     
+    -ms-user-select: all;      
+    user-select: all;
+}

--- a/query-graphs/src/ui/QueryNode.tsx
+++ b/query-graphs/src/ui/QueryNode.tsx
@@ -55,7 +55,7 @@ function QueryNode({data, id}: NodeProps<NodeData>) {
     for (const [key, value] of (data.properties || []).entries()) {
         children.push(
             <div key={key}>
-                <span className="qg-prop-name">{key}:</span> {value}
+                <span className="qg-prop-name">{key}:</span> <span className="qg-prop-value">{value}</span>
             </div>,
         );
     }


### PR DESCRIPTION
Allow the user to select the values under `qg-graph-node-body` by introducing a new CSS class `qg-prop-value` and using it to set the CSS property `user-select` to `all`.

This keeps all of the existing behaviour of query graph nodes, i.e. clicking it anywhere to expand/collapse, but still makes it possible to copy out information by right-clicking.

Not being able to do this was a bit of a nuisance sometimes.