### PR TITLE
Properly render plans of failed queries

### DIFF
--- a/query-graphs/src/tree-description.ts
+++ b/query-graphs/src/tree-description.ts
@@ -47,9 +47,8 @@ export interface Crosslink {
 export interface TreeDescription {
     /// The tree root
     root: TreeNode;
-    /// Displayed in the top-level tree label
-    /// XXX remove
-    properties?: Map<string, string>;
+    /// Metadata about the graph; displayed in the top-level tree label
+    metadata?: Map<string, string>;
     /// Additional links between indirectly related nodes
     crosslinks?: Crosslink[];
 }

--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -88,11 +88,13 @@
 
 .qg-prop-name {
     color: hsl(0, 0%, 50%);
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .qg-prop-value {
-    -webkit-user-select: all;  
-    -moz-user-select: all;     
-    -ms-user-select: all;      
-    user-select: all;
+    -webkit-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
 }

--- a/standalone-app/src/QueryGraphsApp.tsx
+++ b/standalone-app/src/QueryGraphsApp.tsx
@@ -122,7 +122,7 @@ export function QueryGraphsApp() {
     } else {
         return (
             <QueryGraph treeDescription={tree}>
-                <TreeLabel title={treeTitle ?? ""} setTitle={setTreeTitle} />
+                <TreeLabel title={treeTitle ?? ""} setTitle={setTreeTitle} metadata={tree.metadata} />
             </QueryGraph>
         );
     }

--- a/standalone-app/src/TreeLabel.css
+++ b/standalone-app/src/TreeLabel.css
@@ -1,5 +1,6 @@
 .graph-title {
-    font-size: 1.2em;
+    background: #fff;
+    font-size: 1.1em;
     font-weight: bold;
     field-sizing: content;
     min-width: 10em;
@@ -8,4 +9,10 @@
 
 .graph-title:hover {
     background: #ffeded;
+}
+
+.graph-metadata {
+    background: #fff;
+    max-width: 20em;
+    word-break: break-all;
 }

--- a/standalone-app/src/TreeLabel.tsx
+++ b/standalone-app/src/TreeLabel.tsx
@@ -1,11 +1,22 @@
+import {ReactElement} from "react";
 import "./TreeLabel.css";
 
 export interface TreeLabelProps {
     title: string;
     setTitle?: (v: string) => void;
+    metadata?: Map<string, string>;
 }
 
-export function TreeLabel({title, setTitle}: TreeLabelProps) {
+export function TreeLabel({title, setTitle, metadata}: TreeLabelProps) {
+    const metadataChildren = [] as ReactElement[];
+    for (const [key, value] of (metadata || []).entries()) {
+        metadataChildren.push(
+            <div key={key}>
+                <span className="qg-prop-name">{key}:</span> <span className="qg-prop-value">{value}</span>
+            </div>,
+        );
+    }
+
     return (
         <div className="react-flow__panel">
             <input
@@ -15,6 +26,7 @@ export function TreeLabel({title, setTitle}: TreeLabelProps) {
                 value={title}
                 onChange={(e) => (setTitle ? setTitle(e.target.value) : undefined)}
             />
+            <div className="graph-metadata">{metadataChildren}</div>
         </div>
     );
 }


### PR DESCRIPTION
For query plans of queries which errored-out, we now:
* Show the error message top-level, right under the graph title
* Highlight the failed operator in red