### PR TITLE
Use cpu-cycles instead of execution-time to highlight operators with higher cpu consumption

### DIFF
--- a/query-graphs/src/hyper.ts
+++ b/query-graphs/src/hyper.ts
@@ -230,7 +230,7 @@ function convertHyperNode(rawNode: Json, parentKey, conversionState: ConversionS
         }
 
         // Information on the execution time
-        const execTime = tryGetPropertyPath(rawNode, ["analyze", "execution-time"]);
+        const execTime = tryGetPropertyPath(rawNode, ["analyze", "cpu-cycles"]);
         if (typeof execTime === "number") {
             conversionState.runtimes.push({node: convertedNode, time: execTime});
         }

--- a/standalone-app/examples/hyper/tpch-q11-error-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch-q11-error-analyze.plan.json
@@ -51,7 +51,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "nation"},
                 "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "GERMANY"}}}],
                 "selectivity": 0.04,
-                "analyze": {"pipeline": 5, "execution-time": 4527, "running": false, "tuple-count": 1}
+                "analyze": {"pipeline": 5, "cpu-cycles": 4527, "running": false, "tuple-count": 1}
               },
               "right": {
                 "operator": "tablescan",
@@ -64,7 +64,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "supplier"},
                 "earlyProbes": [{"builder": 7, "attributes": [3], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 4, "execution-time": 798, "running": false, "tuple-count": 19}
+                "analyze": {"pipeline": 4, "cpu-cycles": 798, "running": false, "tuple-count": 19}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v3"}},
               "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 19}
@@ -80,7 +80,7 @@
               "debugName": {"classification": "nonsensitive", "value": "partsupp"},
               "earlyProbes": [{"builder": 6, "attributes": [1], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 3, "execution-time": 1158, "running": false, "tuple-count": 58}
+              "analyze": {"pipeline": 3, "cpu-cycles": 1158, "running": false, "tuple-count": 58}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v5"}},
             "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 21}
@@ -89,7 +89,7 @@
           "emptyGroups": true,
           "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "iuref", "iu": "v8"}}}],
           "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v10", ["BigNumeric", 38, 2, "nullable"]]}],
-          "analyze": {"pipeline": 2, "execution-time": 17, "memory-bytes": 0, "running": false, "tuple-count": 1}
+          "analyze": {"pipeline": 2, "cpu-cycles": 17, "memory-bytes": 0, "running": false, "tuple-count": 1}
         },
         "values": [{"iu": ["v11", ["BigNumeric", 38, 6, "nullable"]], "value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "const", "value": {"type": ["Numeric", 5, 4], "value": 1}}}}],
         "analyze": {"pipeline": 2, "tuple-count": 1}
@@ -122,7 +122,7 @@
               "debugName": {"classification": "nonsensitive", "value": "nation"},
               "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "GERMANY"}}}],
               "selectivity": 0.04,
-              "analyze": {"pipeline": 8, "execution-time": 46, "running": false, "tuple-count": 1}
+              "analyze": {"pipeline": 8, "cpu-cycles": 46, "running": false, "tuple-count": 1}
             },
             "right": {
               "operator": "tablescan",
@@ -135,7 +135,7 @@
               "debugName": {"classification": "nonsensitive", "value": "supplier"},
               "earlyProbes": [{"builder": 13, "attributes": [3], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 7, "execution-time": 148, "running": false, "tuple-count": 19}
+              "analyze": {"pipeline": 7, "cpu-cycles": 148, "running": false, "tuple-count": 19}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v15"}, "right": {"expression": "iuref", "iu": "v12"}},
             "analyze": {"pipeline": 7, "memory-bytes": 18432, "tuple-count": 19}
@@ -151,7 +151,7 @@
             "debugName": {"classification": "nonsensitive", "value": "partsupp"},
             "earlyProbes": [{"builder": 12, "attributes": [1], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 6, "execution-time": 839, "running": false, "tuple-count": 58}
+            "analyze": {"pipeline": 6, "cpu-cycles": 839, "running": false, "tuple-count": 58}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v17"}, "right": {"expression": "iuref", "iu": "v14"}},
           "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 21}
@@ -161,12 +161,12 @@
         "emptyGroups": false,
         "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v18"}}}],
         "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigNumeric", 38, 2]]}],
-        "analyze": {"pipeline": 1, "execution-time": 0, "memory-bytes": 18432, "running": true, "tuple-count": 0}
+        "analyze": {"pipeline": 1, "cpu-cycles": 0, "memory-bytes": 18432, "running": true, "tuple-count": 0}
       },
       "condition": {"expression": "comparison", "mode": ">", "left": {"expression": "iuref", "iu": "v2"}, "right": {"expression": "div", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 0}}}},
       "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 0}
     },
-    "analyze": {"pipeline": 0, "execution-time": 0, "memory-bytes": 0, "running": false, "tuple-count": 0}
+    "analyze": {"pipeline": 0, "cpu-cycles": 0, "memory-bytes": 0, "running": false, "tuple-count": 0}
   },
   "analyze": {"error": {"code": "22012", "message": {"original": "division by zero", "translation": "division by zero"}, "detail": null, "internalDetail": null, "hint": null}, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q1-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q1-analyze.plan.json
@@ -27,16 +27,16 @@
         "debugName": {"classification": "nonsensitive", "value": "lineitem"},
         "restrictions": [{"attribute": 10, "mode": "<=", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2451059}}}],
         "selectivity": 0.993007,
-        "analyze": {"pipeline": 2, "execution-time": 2717, "running": false, "tuple-count": 568}
+        "analyze": {"pipeline": 2, "cpu-cycles": 2717, "running": false, "tuple-count": 568}
       },
       "keyExpressions": [{"expression": {"value": {"expression": "iuref", "iu": "v15"}}, "iu": ["v", ["Char1"]]}, {"expression": {"value": {"expression": "iuref", "iu": "v16"}}, "iu": ["v2", ["Char1"]]}],
       "groupingSets": [{"keyIndices": [0, 1], "coreIndices": [0, 1], "behavior": "regular"}],
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v11"}}, {"value": {"expression": "iuref", "iu": "v12"}}, {"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v13"}}, "right": {"expression": "iuref", "iu": "v12"}}}, {"value": {"expression": "mul", "left": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v13"}}, "right": {"expression": "iuref", "iu": "v12"}}, "right": {"expression": "add", "left": {"expression": "iuref", "iu": "v14"}, "right": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}}}}, {"value": {"expression": "iuref", "iu": "v13"}}],
       "aggregates": [{"source": 4294967295, "operation": {"aggregate": "count"}, "iu": ["v10", ["BigInt"]]}, {"source": 0, "operation": {"aggregate": "avg"}, "iu": ["v7", ["Numeric", 16, 6]]}, {"source": 4, "operation": {"aggregate": "avg"}, "iu": ["v9", ["Numeric", 16, 6]]}, {"source": 3, "operation": {"aggregate": "sum"}, "iu": ["v6", ["BigNumeric", 38, 6]]}, {"source": 1, "operation": {"aggregate": "avg"}, "iu": ["v8", ["Numeric", 16, 6]]}, {"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v3", ["BigNumeric", 38, 2]]}, {"source": 1, "operation": {"aggregate": "sum"}, "iu": ["v4", ["BigNumeric", 38, 2]]}, {"source": 2, "operation": {"aggregate": "sum"}, "iu": ["v5", ["BigNumeric", 38, 4]]}],
-      "analyze": {"pipeline": 1, "execution-time": 187, "memory-bytes": 18432, "running": false, "tuple-count": 4}
+      "analyze": {"pipeline": 1, "cpu-cycles": 187, "memory-bytes": 18432, "running": false, "tuple-count": 4}
     },
-    "analyze": {"pipeline": 0, "execution-time": 91, "memory-bytes": 262176, "running": false, "tuple-count": 4}
+    "analyze": {"pipeline": 0, "cpu-cycles": 91, "memory-bytes": 262176, "running": false, "tuple-count": 4}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q10-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q10-analyze.plan.json
@@ -46,7 +46,7 @@
               "debugName": {"classification": "nonsensitive", "value": "orders"},
               "restrictions": [{"attribute": 4, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449262}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2449354}}}],
               "selectivity": 0.0703125,
-              "analyze": {"pipeline": 5, "execution-time": 136, "running": false, "tuple-count": 9}
+              "analyze": {"pipeline": 5, "cpu-cycles": 136, "running": false, "tuple-count": 9}
             },
             "right": {
               "operator": "tablescan",
@@ -59,7 +59,7 @@
               "debugName": {"classification": "nonsensitive", "value": "customer"},
               "earlyProbes": [{"builder": 6, "attributes": [0], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 4, "execution-time": 284, "running": false, "tuple-count": 15}
+              "analyze": {"pipeline": 4, "cpu-cycles": 284, "running": false, "tuple-count": 15}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v12"}, "right": {"expression": "iuref", "iu": "v10"}},
             "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 9}
@@ -75,7 +75,7 @@
             "debugName": {"classification": "nonsensitive", "value": "nation"},
             "earlyProbes": [{"builder": 5, "attributes": [0], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 3, "execution-time": 145, "running": false, "tuple-count": 11}
+            "analyze": {"pipeline": 3, "cpu-cycles": 145, "running": false, "tuple-count": 11}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v15"}, "right": {"expression": "iuref", "iu": "v19"}},
           "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 9}
@@ -92,7 +92,7 @@
           "restrictions": [{"attribute": 8, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char1"], "value": 82}}}],
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 0.265734,
-          "analyze": {"pipeline": 2, "execution-time": 411, "running": false, "tuple-count": 37}
+          "analyze": {"pipeline": 2, "cpu-cycles": 411, "running": false, "tuple-count": 37}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v21"}, "right": {"expression": "iuref", "iu": "v9"}},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 23}
@@ -102,9 +102,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v23"}}, "right": {"expression": "iuref", "iu": "v22"}}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v3", ["BigNumeric", 38, 4]]}],
-      "analyze": {"pipeline": 1, "execution-time": 243, "memory-bytes": 18432, "running": false, "tuple-count": 8}
+      "analyze": {"pipeline": 1, "cpu-cycles": 243, "memory-bytes": 18432, "running": false, "tuple-count": 8}
     },
-    "analyze": {"pipeline": 0, "execution-time": 175, "heap-gc-passes": 0, "memory-bytes": 262208, "running": false, "tuple-count": 8}
+    "analyze": {"pipeline": 0, "cpu-cycles": 175, "heap-gc-passes": 0, "memory-bytes": 262208, "running": false, "tuple-count": 8}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q11-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q11-analyze.plan.json
@@ -50,7 +50,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "nation"},
                 "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "GERMANY"}}}],
                 "selectivity": 0.04,
-                "analyze": {"pipeline": 5, "execution-time": 485, "running": false, "tuple-count": 1}
+                "analyze": {"pipeline": 5, "cpu-cycles": 485, "running": false, "tuple-count": 1}
               },
               "right": {
                 "operator": "tablescan",
@@ -63,7 +63,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "supplier"},
                 "earlyProbes": [{"builder": 7, "attributes": [3], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 4, "execution-time": 700, "running": false, "tuple-count": 19}
+                "analyze": {"pipeline": 4, "cpu-cycles": 700, "running": false, "tuple-count": 19}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v3"}},
               "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 19}
@@ -79,7 +79,7 @@
               "debugName": {"classification": "nonsensitive", "value": "partsupp"},
               "earlyProbes": [{"builder": 6, "attributes": [1], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 3, "execution-time": 957, "running": false, "tuple-count": 58}
+              "analyze": {"pipeline": 3, "cpu-cycles": 957, "running": false, "tuple-count": 58}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v5"}},
             "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 21}
@@ -88,7 +88,7 @@
           "emptyGroups": true,
           "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "iuref", "iu": "v8"}}}],
           "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v10", ["BigNumeric", 38, 2, "nullable"]]}],
-          "analyze": {"pipeline": 2, "execution-time": 12, "memory-bytes": 0, "running": false, "tuple-count": 1}
+          "analyze": {"pipeline": 2, "cpu-cycles": 12, "memory-bytes": 0, "running": false, "tuple-count": 1}
         },
         "values": [{"iu": ["v11", ["BigNumeric", 38, 6, "nullable"]], "value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "const", "value": {"type": ["Numeric", 5, 4], "value": 1}}}}],
         "analyze": {"pipeline": 2, "tuple-count": 1}
@@ -121,7 +121,7 @@
               "debugName": {"classification": "nonsensitive", "value": "nation"},
               "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "GERMANY"}}}],
               "selectivity": 0.04,
-              "analyze": {"pipeline": 8, "execution-time": 41, "running": false, "tuple-count": 1}
+              "analyze": {"pipeline": 8, "cpu-cycles": 41, "running": false, "tuple-count": 1}
             },
             "right": {
               "operator": "tablescan",
@@ -134,7 +134,7 @@
               "debugName": {"classification": "nonsensitive", "value": "supplier"},
               "earlyProbes": [{"builder": 13, "attributes": [3], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 7, "execution-time": 129, "running": false, "tuple-count": 19}
+              "analyze": {"pipeline": 7, "cpu-cycles": 129, "running": false, "tuple-count": 19}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v15"}, "right": {"expression": "iuref", "iu": "v12"}},
             "analyze": {"pipeline": 7, "memory-bytes": 18432, "tuple-count": 19}
@@ -150,7 +150,7 @@
             "debugName": {"classification": "nonsensitive", "value": "partsupp"},
             "earlyProbes": [{"builder": 12, "attributes": [1], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 6, "execution-time": 749, "running": false, "tuple-count": 58}
+            "analyze": {"pipeline": 6, "cpu-cycles": 749, "running": false, "tuple-count": 58}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v17"}, "right": {"expression": "iuref", "iu": "v14"}},
           "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 21}
@@ -160,12 +160,12 @@
         "emptyGroups": false,
         "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v18"}}}],
         "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigNumeric", 38, 2]]}],
-        "analyze": {"pipeline": 1, "execution-time": 254, "memory-bytes": 18432, "running": false, "tuple-count": 21}
+        "analyze": {"pipeline": 1, "cpu-cycles": 254, "memory-bytes": 18432, "running": false, "tuple-count": 21}
       },
       "condition": {"expression": "comparison", "mode": ">", "left": {"expression": "iuref", "iu": "v2"}, "right": {"expression": "iuref", "iu": "v11"}},
       "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 21}
     },
-    "analyze": {"pipeline": 0, "execution-time": 233, "memory-bytes": 262312, "running": false, "tuple-count": 21}
+    "analyze": {"pipeline": 0, "cpu-cycles": 233, "memory-bytes": 262312, "running": false, "tuple-count": 21}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q12-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q12-analyze.plan.json
@@ -34,7 +34,7 @@
           "restrictions": [{"attribute": 12, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449354}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2449719}}}, {"attribute": 14, "mode": "lambda", "expression": {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v8"}], "values": [{"type": ["Char", 10], "value": "MAIL"}, {"type": ["Char", 10], "value": "SHIP"}], "collates": [null], "modes": ["equals"]}}],
           "residuals": [{"expression": "comparison", "mode": "<", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v7"}}, {"expression": "comparison", "mode": "<", "left": {"expression": "iuref", "iu": "v5"}, "right": {"expression": "iuref", "iu": "v6"}}],
           "selectivity": 0.0458916,
-          "analyze": {"pipeline": 3, "execution-time": 704, "running": false, "tuple-count": 2}
+          "analyze": {"pipeline": 3, "cpu-cycles": 704, "running": false, "tuple-count": 2}
         },
         "right": {
           "operator": "tablescan",
@@ -47,7 +47,7 @@
           "debugName": {"classification": "nonsensitive", "value": "orders"},
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 2, "execution-time": 232, "running": false, "tuple-count": 4}
+          "analyze": {"pipeline": 2, "cpu-cycles": 232, "running": false, "tuple-count": 4}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "iuref", "iu": "v4"}},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 2}
@@ -57,9 +57,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "simplecase", "value": {"expression": "iuref", "iu": "v10"}, "cases": [{"cases": [{"expression": "const", "value": {"type": ["Varchar"], "value": "1-URGENT"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "2-HIGH"}}], "value": {"expression": "const", "value": {"type": ["Integer"], "value": 1}}}], "else": {"expression": "const", "value": {"type": ["Integer"], "value": 0}}}}, {"value": {"expression": "case", "cases": [{"case": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "<>", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "const", "value": {"type": ["Char", 15], "value": "1-URGENT"}}}, {"expression": "comparison", "mode": "<>", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "const", "value": {"type": ["Char", 15], "value": "2-HIGH"}}}]}, "value": {"expression": "const", "value": {"type": ["Integer"], "value": 1}}}], "else": {"expression": "const", "value": {"type": ["Integer"], "value": 0}}}}],
       "aggregates": [{"source": 1, "operation": {"aggregate": "sum"}, "iu": ["v3", ["BigInt"]]}, {"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigInt"]]}],
-      "analyze": {"pipeline": 1, "execution-time": 208, "memory-bytes": 18432, "running": false, "tuple-count": 2}
+      "analyze": {"pipeline": 1, "cpu-cycles": 208, "memory-bytes": 18432, "running": false, "tuple-count": 2}
     },
-    "analyze": {"pipeline": 0, "execution-time": 26, "memory-bytes": 262160, "running": false, "tuple-count": 2}
+    "analyze": {"pipeline": 0, "cpu-cycles": 26, "memory-bytes": 262160, "running": false, "tuple-count": 2}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q13-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q13-analyze.plan.json
@@ -37,7 +37,7 @@
             "debugName": {"classification": "nonsensitive", "value": "orders"},
             "restrictions": [{"attribute": 8, "mode": "lambda", "expression": {"expression": "not", "input": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v5"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "%special%requests%"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}}}],
             "selectivity": 1,
-            "analyze": {"pipeline": 4, "execution-time": 433, "running": false, "tuple-count": 128}
+            "analyze": {"pipeline": 4, "cpu-cycles": 433, "running": false, "tuple-count": 128}
           },
           "right": {
             "operator": "tablescan",
@@ -49,7 +49,7 @@
             "values": [{"name": "c_custkey", "type": ["Integer"], "iu": ["v6", ["Integer"]]}, {"name": "c_name", "type": ["Varchar", 25], "iu": null}, {"name": "c_address", "type": ["Varchar", 40], "iu": null}, {"name": "c_nationkey", "type": ["Integer"], "iu": null}, {"name": "c_phone", "type": ["Char", 15], "iu": null}, {"name": "c_acctbal", "type": ["Numeric", 12, 2], "iu": null}, {"name": "c_mktsegment", "type": ["Char", 10], "iu": null}, {"name": "c_comment", "type": ["Varchar", 117], "iu": null}],
             "debugName": {"classification": "nonsensitive", "value": "customer"},
             "selectivity": 1,
-            "analyze": {"pipeline": 3, "execution-time": 938, "running": false, "tuple-count": 129}
+            "analyze": {"pipeline": 3, "cpu-cycles": 938, "running": false, "tuple-count": 129}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v4"}},
           "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 129}
@@ -59,15 +59,15 @@
         "emptyGroups": false,
         "aggExpressions": [{"value": {"expression": "iuref", "iu": "v3"}}],
         "aggregates": [{"source": 0, "operation": {"aggregate": "count"}, "iu": ["v8", ["BigInt"]]}],
-        "analyze": {"pipeline": 2, "execution-time": 570, "memory-bytes": 20480, "running": false, "tuple-count": 129}
+        "analyze": {"pipeline": 2, "cpu-cycles": 570, "memory-bytes": 20480, "running": false, "tuple-count": 129}
       },
       "keyExpressions": [{"expression": {"value": {"expression": "iuref", "iu": "v8"}}, "iu": ["v", ["BigInt"]]}],
       "groupingSets": [{"keyIndices": [0], "coreIndices": [0], "behavior": "regular"}],
       "emptyGroups": false,
       "aggregates": [{"source": 4294967295, "operation": {"aggregate": "count"}, "iu": ["v2", ["BigInt"]]}],
-      "analyze": {"pipeline": 1, "execution-time": 244, "memory-bytes": 18432, "running": false, "tuple-count": 2}
+      "analyze": {"pipeline": 1, "cpu-cycles": 244, "memory-bytes": 18432, "running": false, "tuple-count": 2}
     },
-    "analyze": {"pipeline": 0, "execution-time": 17, "memory-bytes": 262160, "running": false, "tuple-count": 2}
+    "analyze": {"pipeline": 0, "cpu-cycles": 17, "memory-bytes": 262160, "running": false, "tuple-count": 2}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q14-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q14-analyze.plan.json
@@ -32,7 +32,7 @@
           "debugName": {"classification": "nonsensitive", "value": "lineitem"},
           "restrictions": [{"attribute": 10, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449962}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2449992}}}],
           "selectivity": 0.0192308,
-          "analyze": {"pipeline": 2, "execution-time": 120, "running": false, "tuple-count": 11}
+          "analyze": {"pipeline": 2, "cpu-cycles": 120, "running": false, "tuple-count": 11}
         },
         "right": {
           "operator": "tablescan",
@@ -45,7 +45,7 @@
           "debugName": {"classification": "nonsensitive", "value": "part"},
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 1, "execution-time": 982, "running": false, "tuple-count": 37}
+          "analyze": {"pipeline": 1, "cpu-cycles": 982, "running": false, "tuple-count": 37}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v2"}, "right": {"expression": "iuref", "iu": "v6"}},
         "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 11}
@@ -54,7 +54,7 @@
       "emptyGroups": true,
       "aggExpressions": [{"value": {"expression": "case", "cases": [{"case": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v7"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "PROMO%"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}, "value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v4"}}, "right": {"expression": "iuref", "iu": "v3"}}}], "else": {"expression": "const", "value": {"type": ["BigNumeric", 25, 4], "low": 0, "high": 0}}}}, {"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v4"}}, "right": {"expression": "iuref", "iu": "v3"}}}],
       "aggregates": [{"source": 1, "operation": {"aggregate": "sum"}, "iu": ["v8", ["BigNumeric", 38, 4, "nullable"]]}, {"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v9", ["BigNumeric", 38, 4, "nullable"]]}],
-      "analyze": {"pipeline": 0, "execution-time": 30, "memory-bytes": 0, "running": false, "tuple-count": 1}
+      "analyze": {"pipeline": 0, "cpu-cycles": 30, "memory-bytes": 0, "running": false, "tuple-count": 1}
     },
     "values": [{"iu": ["v", ["BigNumeric", 38, 6, "nullable"]], "value": {"expression": "div", "left": {"expression": "mul", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "const", "value": {"type": ["Numeric", 5, 2], "value": 10000}}}, "right": {"expression": "iuref", "iu": "v8"}}}],
     "analyze": {"pipeline": 0, "tuple-count": 1}

--- a/standalone-app/examples/hyper/tpch/tpch-q15-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q15-analyze.plan.json
@@ -49,22 +49,22 @@
                 "debugName": {"classification": "nonsensitive", "value": "lineitem"},
                 "restrictions": [{"attribute": 10, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2450084}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2450175}}}],
                 "selectivity": 0.0874126,
-                "analyze": {"pipeline": 6, "execution-time": 223, "running": false, "tuple-count": 50}
+                "analyze": {"pipeline": 6, "cpu-cycles": 223, "running": false, "tuple-count": 50}
               },
               "keyExpressions": [{"expression": {"value": {"expression": "iuref", "iu": "v10"}}, "iu": ["v6", ["Integer"]]}],
               "groupingSets": [{"keyIndices": [0], "coreIndices": [0], "behavior": "regular"}],
               "emptyGroups": false,
               "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v12"}}, "right": {"expression": "iuref", "iu": "v11"}}}],
               "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v8", ["BigNumeric", 38, 4]]}],
-              "analyze": {"pipeline": 5, "execution-time": 0, "memory-bytes": 18432, "running": false, "tuple-count": 0}
+              "analyze": {"pipeline": 5, "cpu-cycles": 0, "memory-bytes": 18432, "running": false, "tuple-count": 0}
             },
-            "analyze": {"pipeline": 4, "execution-time": 259, "running": false, "tuple-count": 50}
+            "analyze": {"pipeline": 4, "cpu-cycles": 259, "running": false, "tuple-count": 50}
           },
           "groupingSets": [{"keyIndices": [], "coreIndices": null, "behavior": "static"}],
           "emptyGroups": true,
           "aggExpressions": [{"value": {"expression": "iuref", "iu": "v9"}}],
           "aggregates": [{"source": 0, "operation": {"aggregate": "max"}, "iu": ["v14", ["BigNumeric", 38, 4, "nullable"]]}],
-          "analyze": {"pipeline": 3, "execution-time": 14, "memory-bytes": 0, "running": false, "tuple-count": 1}
+          "analyze": {"pipeline": 3, "cpu-cycles": 14, "memory-bytes": 0, "running": false, "tuple-count": 1}
         },
         "right": {
           "operator": "explicitscan",
@@ -72,7 +72,7 @@
           "cardinality": 50,
           "mapping": [{"source": {"expression": "iuref", "iu": "v6"}, "target": ["v15", ["Integer"]]}, {"source": {"expression": "iuref", "iu": "v8"}, "target": ["v5", ["BigNumeric", 38, 4]]}],
           "input": 7,
-          "analyze": {"pipeline": 2, "execution-time": 276, "running": false, "tuple-count": 50}
+          "analyze": {"pipeline": 2, "cpu-cycles": 276, "running": false, "tuple-count": 50}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v5"}, "right": {"expression": "iuref", "iu": "v14"}},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 1}
@@ -88,12 +88,12 @@
         "debugName": {"classification": "nonsensitive", "value": "supplier"},
         "earlyProbes": [{"builder": 3, "attributes": [0], "type": "lookup"}],
         "selectivity": 1,
-        "analyze": {"pipeline": 1, "execution-time": 90, "running": false, "tuple-count": 1}
+        "analyze": {"pipeline": 1, "cpu-cycles": 90, "running": false, "tuple-count": 1}
       },
       "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v"}, "right": {"expression": "iuref", "iu": "v15"}},
       "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 32, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 32, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q16-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q16-analyze.plan.json
@@ -32,7 +32,7 @@
           "debugName": {"classification": "nonsensitive", "value": "supplier"},
           "restrictions": [{"attribute": 6, "mode": "lambda", "expression": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v6"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "%Customer%Complaints%"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}}],
           "selectivity": 0.0019305,
-          "analyze": {"pipeline": 3, "execution-time": 961, "running": false, "tuple-count": 0}
+          "analyze": {"pipeline": 3, "cpu-cycles": 961, "running": false, "tuple-count": 0}
         },
         "right": {
           "operator": "join",
@@ -51,7 +51,7 @@
             "debugName": {"classification": "nonsensitive", "value": "part"},
             "restrictions": [{"attribute": 5, "mode": "lambda", "expression": {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v10"}], "values": [{"type": ["Integer"], "value": 3}, {"type": ["Integer"], "value": 9}, {"type": ["Integer"], "value": 14}, {"type": ["Integer"], "value": 19}, {"type": ["Integer"], "value": 23}, {"type": ["Integer"], "value": 36}, {"type": ["Integer"], "value": 45}, {"type": ["Integer"], "value": 49}], "collates": [null], "modes": ["equals"]}}, {"attribute": 4, "mode": "lambda", "expression": {"expression": "not", "input": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v9"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "MEDIUM POLISHED%"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}}}, {"attribute": 3, "mode": "lambda", "expression": {"expression": "comparison", "mode": "<>", "left": {"expression": "iuref", "iu": "v8"}, "right": {"expression": "const", "value": {"type": ["Char", 10], "value": "Brand#45"}}}}],
             "selectivity": 0.15197,
-            "analyze": {"pipeline": 4, "execution-time": 1935, "running": false, "tuple-count": 81}
+            "analyze": {"pipeline": 4, "cpu-cycles": 1935, "running": false, "tuple-count": 81}
           },
           "right": {
             "operator": "tablescan",
@@ -64,7 +64,7 @@
             "debugName": {"classification": "nonsensitive", "value": "partsupp"},
             "earlyProbes": [{"builder": 6, "attributes": [0], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 2, "execution-time": 2076, "running": false, "tuple-count": 185}
+            "analyze": {"pipeline": 2, "cpu-cycles": 2076, "running": false, "tuple-count": 185}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v11"}},
           "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 81}
@@ -77,9 +77,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v12"}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "count", "distinct": true}, "iu": ["v4", ["BigInt"]]}],
-      "analyze": {"pipeline": 1, "execution-time": 637, "memory-bytes": 36864, "running": false, "tuple-count": 81}
+      "analyze": {"pipeline": 1, "cpu-cycles": 637, "memory-bytes": 36864, "running": false, "tuple-count": 81}
     },
-    "analyze": {"pipeline": 0, "execution-time": 198, "memory-bytes": 262792, "running": false, "tuple-count": 81}
+    "analyze": {"pipeline": 0, "cpu-cycles": 198, "memory-bytes": 262792, "running": false, "tuple-count": 81}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q17-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q17-analyze.plan.json
@@ -38,7 +38,7 @@
             "debugName": {"classification": "nonsensitive", "value": "part"},
             "restrictions": [{"attribute": 6, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 10], "value": "MED BOX"}}}, {"attribute": 3, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 10], "value": "Brand#23"}}}],
             "selectivity": 0.00562852,
-            "analyze": {"pipeline": 3, "execution-time": 137, "running": false, "tuple-count": 3}
+            "analyze": {"pipeline": 3, "cpu-cycles": 137, "running": false, "tuple-count": 3}
           },
           "right": {
             "operator": "map",
@@ -62,14 +62,14 @@
                 "residuals": [{"expression": "const", "value": {"type": ["Bool"], "value": true}}],
                 "earlyProbes": [{"builder": 5, "attributes": [1], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 4, "execution-time": 952, "running": false, "tuple-count": 50}
+                "analyze": {"pipeline": 4, "cpu-cycles": 952, "running": false, "tuple-count": 50}
               },
               "keyExpressions": [{"expression": {"value": {"expression": "iuref", "iu": "v5"}}, "iu": ["v7", ["Integer"]]}],
               "groupingSets": [{"keyIndices": [0], "coreIndices": [0], "behavior": "regular"}],
               "emptyGroups": true,
               "aggExpressions": [{"value": {"expression": "iuref", "iu": "v6"}}],
               "aggregates": [{"source": 0, "operation": {"aggregate": "avg"}, "iu": ["v8", ["Numeric", 16, 6, "nullable"]]}],
-              "analyze": {"pipeline": 2, "execution-time": 274, "memory-bytes": 18432, "running": false, "tuple-count": 12}
+              "analyze": {"pipeline": 2, "cpu-cycles": 274, "memory-bytes": 18432, "running": false, "tuple-count": 12}
             },
             "values": [{"iu": ["v9", ["Numeric", 18, 7, "nullable"]], "value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v8"}, "right": {"expression": "const", "value": {"type": ["Numeric", 2, 1], "value": 2}}}}],
             "analyze": {"pipeline": 2, "tuple-count": 12}
@@ -88,7 +88,7 @@
           "debugName": {"classification": "nonsensitive", "value": "lineitem"},
           "earlyProbes": [{"builder": 4, "attributes": [1, 1], "type": "minmaxonly"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 1, "execution-time": 1380, "running": false, "tuple-count": 572}
+          "analyze": {"pipeline": 1, "cpu-cycles": 1380, "running": false, "tuple-count": 572}
         },
         "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "iuref", "iu": "v7"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v2"}, "right": {"expression": "iuref", "iu": "v10"}}, {"expression": "comparison", "mode": "<", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v9"}}]},
         "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 2}
@@ -97,7 +97,7 @@
       "emptyGroups": true,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v12"}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v13", ["BigNumeric", 38, 2, "nullable"]]}],
-      "analyze": {"pipeline": 0, "execution-time": 20, "memory-bytes": 0, "running": false, "tuple-count": 1}
+      "analyze": {"pipeline": 0, "cpu-cycles": 20, "memory-bytes": 0, "running": false, "tuple-count": 1}
     },
     "values": [{"iu": ["v", ["BigNumeric", 38, 6, "nullable"]], "value": {"expression": "div", "left": {"expression": "iuref", "iu": "v13"}, "right": {"expression": "const", "value": {"type": ["Numeric", 2, 1], "value": 70}}}}],
     "analyze": {"pipeline": 0, "tuple-count": 1}

--- a/standalone-app/examples/hyper/tpch/tpch-q18-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q18-analyze.plan.json
@@ -55,14 +55,14 @@
                   "values": [{"name": "l_orderkey", "type": ["Integer"], "iu": ["v7", ["Integer"]]}, {"name": "l_partkey", "type": ["Integer"], "iu": null}, {"name": "l_suppkey", "type": ["Integer"], "iu": null}, {"name": "l_linenumber", "type": ["Integer"], "iu": null}, {"name": "l_quantity", "type": ["Numeric", 12, 2], "iu": ["v8", ["Numeric", 12, 2]]}, {"name": "l_extendedprice", "type": ["Numeric", 12, 2], "iu": null}, {"name": "l_discount", "type": ["Numeric", 12, 2], "iu": null}, {"name": "l_tax", "type": ["Numeric", 12, 2], "iu": null}, {"name": "l_returnflag", "type": ["Char1"], "iu": null}, {"name": "l_linestatus", "type": ["Char1"], "iu": null}, {"name": "l_shipdate", "type": ["Date"], "iu": null}, {"name": "l_commitdate", "type": ["Date"], "iu": null}, {"name": "l_receiptdate", "type": ["Date"], "iu": null}, {"name": "l_shipinstruct", "type": ["Char", 25], "iu": null}, {"name": "l_shipmode", "type": ["Char", 10], "iu": null}, {"name": "l_comment", "type": ["Varchar", 44], "iu": null}],
                   "debugName": {"classification": "nonsensitive", "value": "lineitem"},
                   "selectivity": 1,
-                  "analyze": {"pipeline": 6, "execution-time": 1449, "running": false, "tuple-count": 572}
+                  "analyze": {"pipeline": 6, "cpu-cycles": 1449, "running": false, "tuple-count": 572}
                 },
                 "keyExpressions": [{"expression": {"value": {"expression": "iuref", "iu": "v7"}}, "iu": ["v9", ["Integer"]]}],
                 "groupingSets": [{"keyIndices": [0], "coreIndices": [0], "behavior": "regular"}],
                 "emptyGroups": false,
                 "aggExpressions": [{"value": {"expression": "iuref", "iu": "v8"}}],
                 "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v10", ["BigNumeric", 38, 2]]}],
-                "analyze": {"pipeline": 5, "execution-time": 306, "memory-bytes": 18432, "running": false, "tuple-count": 128}
+                "analyze": {"pipeline": 5, "cpu-cycles": 306, "memory-bytes": 18432, "running": false, "tuple-count": 128}
               },
               "condition": {"expression": "comparison", "mode": ">", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "const", "value": {"type": ["BigNumeric", 38, 2], "low": 30000, "high": 0}}},
               "analyze": {"pipeline": 5, "tuple-count": 2}
@@ -78,7 +78,7 @@
               "debugName": {"classification": "nonsensitive", "value": "orders"},
               "earlyProbes": [{"builder": 6, "attributes": [0], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 4, "execution-time": 204, "running": false, "tuple-count": 2}
+              "analyze": {"pipeline": 4, "cpu-cycles": 204, "running": false, "tuple-count": 2}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v9"}},
             "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 2}
@@ -94,7 +94,7 @@
             "debugName": {"classification": "nonsensitive", "value": "customer"},
             "earlyProbes": [{"builder": 5, "attributes": [0], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 3, "execution-time": 179, "running": false, "tuple-count": 2}
+            "analyze": {"pipeline": 3, "cpu-cycles": 179, "running": false, "tuple-count": 2}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v15"}, "right": {"expression": "iuref", "iu": "v12"}},
           "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 2}
@@ -110,7 +110,7 @@
           "debugName": {"classification": "nonsensitive", "value": "lineitem"},
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 2, "execution-time": 641, "running": false, "tuple-count": 15}
+          "analyze": {"pipeline": 2, "cpu-cycles": 641, "running": false, "tuple-count": 15}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v17"}},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 14}
@@ -120,9 +120,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v18"}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v6", ["BigNumeric", 38, 2]]}],
-      "analyze": {"pipeline": 1, "execution-time": 178, "memory-bytes": 18432, "running": false, "tuple-count": 2}
+      "analyze": {"pipeline": 1, "cpu-cycles": 178, "memory-bytes": 18432, "running": false, "tuple-count": 2}
     },
-    "analyze": {"pipeline": 0, "execution-time": 245, "heap-gc-passes": 0, "memory-bytes": 262160, "running": false, "tuple-count": 2}
+    "analyze": {"pipeline": 0, "cpu-cycles": 245, "heap-gc-passes": 0, "memory-bytes": 262160, "running": false, "tuple-count": 2}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q19-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q19-analyze.plan.json
@@ -27,7 +27,7 @@
         "debugName": {"classification": "nonsensitive", "value": "lineitem"},
         "restrictions": [{"attribute": 13, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "DELIVER IN PERSON"}}}, {"attribute": 14, "mode": "lambda", "expression": {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v7"}], "values": [{"type": ["Char", 10], "value": "AIR"}, {"type": ["Char", 10], "value": "AIR REG"}], "collates": [null], "modes": ["equals"]}}],
         "selectivity": 0.0402098,
-        "analyze": {"pipeline": 2, "execution-time": 309, "running": false, "tuple-count": 23}
+        "analyze": {"pipeline": 2, "cpu-cycles": 309, "running": false, "tuple-count": 23}
       },
       "right": {
         "operator": "tablescan",
@@ -40,7 +40,7 @@
         "debugName": {"classification": "nonsensitive", "value": "part"},
         "earlyProbes": [{"builder": 3, "attributes": [0], "type": "lookup"}],
         "selectivity": 1,
-        "analyze": {"pipeline": 1, "execution-time": 831, "running": false, "tuple-count": 65}
+        "analyze": {"pipeline": 1, "cpu-cycles": 831, "running": false, "tuple-count": 65}
       },
       "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v8"}, "right": {"expression": "iuref", "iu": "v2"}}, {"expression": "or", "arguments": [{"expression": "and", "arguments": [{"expression": "between", "arguments": [{"expression": "iuref", "iu": "v3"}, {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 100}}, {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 1100}}]}, {"expression": "between", "arguments": [{"expression": "iuref", "iu": "v10"}, {"expression": "const", "value": {"type": ["Integer"], "value": 1}}, {"expression": "const", "value": {"type": ["Integer"], "value": 5}}]}, {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v11"}], "values": [{"type": ["Char", 10], "value": "SM BOX"}, {"type": ["Char", 10], "value": "SM CASE"}, {"type": ["Char", 10], "value": "SM PACK"}, {"type": ["Char", 10], "value": "SM PKG"}], "collates": [null], "modes": ["equals"]}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "const", "value": {"type": ["Char", 10], "value": "Brand#12"}}}]}, {"expression": "and", "arguments": [{"expression": "between", "arguments": [{"expression": "iuref", "iu": "v3"}, {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 1000}}, {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 2000}}]}, {"expression": "between", "arguments": [{"expression": "iuref", "iu": "v10"}, {"expression": "const", "value": {"type": ["Integer"], "value": 1}}, {"expression": "const", "value": {"type": ["Integer"], "value": 10}}]}, {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v11"}], "values": [{"type": ["Char", 10], "value": "MED BAG"}, {"type": ["Char", 10], "value": "MED BOX"}, {"type": ["Char", 10], "value": "MED PACK"}, {"type": ["Char", 10], "value": "MED PKG"}], "collates": [null], "modes": ["equals"]}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "const", "value": {"type": ["Char", 10], "value": "Brand#23"}}}]}, {"expression": "and", "arguments": [{"expression": "between", "arguments": [{"expression": "iuref", "iu": "v3"}, {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 2000}}, {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 3000}}]}, {"expression": "between", "arguments": [{"expression": "iuref", "iu": "v10"}, {"expression": "const", "value": {"type": ["Integer"], "value": 1}}, {"expression": "const", "value": {"type": ["Integer"], "value": 15}}]}, {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v11"}], "values": [{"type": ["Char", 10], "value": "LG BOX"}, {"type": ["Char", 10], "value": "LG CASE"}, {"type": ["Char", 10], "value": "LG PACK"}, {"type": ["Char", 10], "value": "LG PKG"}], "collates": [null], "modes": ["equals"]}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "const", "value": {"type": ["Char", 10], "value": "Brand#34"}}}]}]}]},
       "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 1}
@@ -49,7 +49,7 @@
     "emptyGroups": true,
     "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v5"}}, "right": {"expression": "iuref", "iu": "v4"}}}],
     "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v", ["BigNumeric", 38, 4, "nullable"]]}],
-    "analyze": {"pipeline": 0, "execution-time": 12, "memory-bytes": 0, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 12, "memory-bytes": 0, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q2-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q2-analyze.plan.json
@@ -40,7 +40,7 @@
             "debugName": {"classification": "nonsensitive", "value": "region"},
             "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "EUROPE"}}}],
             "selectivity": 0.2,
-            "analyze": {"pipeline": 4, "execution-time": 98, "running": false, "tuple-count": 1}
+            "analyze": {"pipeline": 4, "cpu-cycles": 98, "running": false, "tuple-count": 1}
           },
           "right": {
             "operator": "tablescan",
@@ -53,7 +53,7 @@
             "debugName": {"classification": "nonsensitive", "value": "nation"},
             "earlyProbes": [{"builder": 5, "attributes": [2], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 3, "execution-time": 101, "running": false, "tuple-count": 5}
+            "analyze": {"pipeline": 3, "cpu-cycles": 101, "running": false, "tuple-count": 5}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v12"}, "right": {"expression": "iuref", "iu": "v9"}},
           "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 5}
@@ -81,7 +81,7 @@
               "debugName": {"classification": "nonsensitive", "value": "part"},
               "restrictions": [{"attribute": 5, "mode": "=", "value": {"expression": "const", "value": {"type": ["Integer"], "value": 15}}}, {"attribute": 4, "mode": "lambda", "expression": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v13"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "%BRASS"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}}],
               "selectivity": 0.011257,
-              "analyze": {"pipeline": 6, "execution-time": 367, "running": false, "tuple-count": 6}
+              "analyze": {"pipeline": 6, "cpu-cycles": 367, "running": false, "tuple-count": 6}
             },
             "right": {
               "operator": "tablescan",
@@ -94,7 +94,7 @@
               "debugName": {"classification": "nonsensitive", "value": "partsupp"},
               "earlyProbes": [{"builder": 9, "attributes": [0], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 5, "execution-time": 614, "running": false, "tuple-count": 17}
+              "analyze": {"pipeline": 5, "cpu-cycles": 614, "running": false, "tuple-count": 17}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v4"}, "right": {"expression": "iuref", "iu": "v15"}},
             "analyze": {"pipeline": 5, "memory-bytes": 18432, "tuple-count": 6}
@@ -110,7 +110,7 @@
             "debugName": {"classification": "nonsensitive", "value": "supplier"},
             "earlyProbes": [{"builder": 8, "attributes": [0], "type": "lookup"}, {"builder": 4, "attributes": [3], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 2, "execution-time": 722, "running": false, "tuple-count": 6}
+            "analyze": {"pipeline": 2, "cpu-cycles": 722, "running": false, "tuple-count": 6}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v18"}, "right": {"expression": "iuref", "iu": "v16"}},
           "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 2}
@@ -152,7 +152,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "region"},
                 "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "EUROPE"}}}],
                 "selectivity": 0.2,
-                "analyze": {"pipeline": 10, "execution-time": 18, "running": false, "tuple-count": 1}
+                "analyze": {"pipeline": 10, "cpu-cycles": 18, "running": false, "tuple-count": 1}
               },
               "right": {
                 "operator": "tablescan",
@@ -165,7 +165,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "nation"},
                 "earlyProbes": [{"builder": 16, "attributes": [2], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 9, "execution-time": 59, "running": false, "tuple-count": 5}
+                "analyze": {"pipeline": 9, "cpu-cycles": 59, "running": false, "tuple-count": 5}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v23"}, "right": {"expression": "iuref", "iu": "v20"}},
               "analyze": {"pipeline": 9, "memory-bytes": 18432, "tuple-count": 5}
@@ -181,7 +181,7 @@
               "debugName": {"classification": "nonsensitive", "value": "supplier"},
               "earlyProbes": [{"builder": 15, "attributes": [3], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 8, "execution-time": 954, "running": false, "tuple-count": 109}
+              "analyze": {"pipeline": 8, "cpu-cycles": 954, "running": false, "tuple-count": 109}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v25"}, "right": {"expression": "iuref", "iu": "v22"}},
             "analyze": {"pipeline": 8, "memory-bytes": 18432, "tuple-count": 90}
@@ -197,7 +197,7 @@
             "debugName": {"classification": "nonsensitive", "value": "partsupp"},
             "earlyProbes": [{"builder": 14, "attributes": [1], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 7, "execution-time": 1588, "running": false, "tuple-count": 238}
+            "analyze": {"pipeline": 7, "cpu-cycles": 1588, "running": false, "tuple-count": 238}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v24"}, "right": {"expression": "iuref", "iu": "v27"}},
           "analyze": {"pipeline": 7, "memory-bytes": 18432, "tuple-count": 95}
@@ -207,12 +207,12 @@
         "emptyGroups": true,
         "aggExpressions": [{"value": {"expression": "iuref", "iu": "v28"}}],
         "aggregates": [{"source": 0, "operation": {"aggregate": "min"}, "iu": ["v30", ["Numeric", 12, 2, "nullable"]]}],
-        "analyze": {"pipeline": 1, "execution-time": 431, "memory-bytes": 18432, "running": false, "tuple-count": 95}
+        "analyze": {"pipeline": 1, "cpu-cycles": 431, "memory-bytes": 18432, "running": false, "tuple-count": 95}
       },
       "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v17"}, "right": {"expression": "iuref", "iu": "v30"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v4"}, "right": {"expression": "iuref", "iu": "v29"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v15"}, "right": {"expression": "iuref", "iu": "v29"}}]},
       "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 2}
     },
-    "analyze": {"pipeline": 0, "execution-time": 43, "heap-gc-passes": 0, "memory-bytes": 262160, "running": false, "tuple-count": 2}
+    "analyze": {"pipeline": 0, "cpu-cycles": 43, "heap-gc-passes": 0, "memory-bytes": 262160, "running": false, "tuple-count": 2}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q20-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q20-analyze.plan.json
@@ -28,7 +28,7 @@
         "debugName": {"classification": "nonsensitive", "value": "nation"},
         "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "CANADA"}}}],
         "selectivity": 0.04,
-        "analyze": {"pipeline": 2, "execution-time": 65, "running": false, "tuple-count": 1}
+        "analyze": {"pipeline": 2, "cpu-cycles": 65, "running": false, "tuple-count": 1}
       },
       "right": {
         "operator": "rightsemijoin",
@@ -59,7 +59,7 @@
               "debugName": {"classification": "nonsensitive", "value": "part"},
               "restrictions": [{"attribute": 1, "mode": "lambda", "expression": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v6"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "forest%"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}}],
               "selectivity": 0.00750469,
-              "analyze": {"pipeline": 5, "execution-time": 463, "running": false, "tuple-count": 4}
+              "analyze": {"pipeline": 5, "cpu-cycles": 463, "running": false, "tuple-count": 4}
             },
             "right": {
               "operator": "tablescan",
@@ -72,7 +72,7 @@
               "debugName": {"classification": "nonsensitive", "value": "partsupp"},
               "earlyProbes": [{"builder": 7, "attributes": [0], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 4, "execution-time": 714, "running": false, "tuple-count": 4}
+              "analyze": {"pipeline": 4, "cpu-cycles": 714, "running": false, "tuple-count": 4}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v5"}},
             "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 4}
@@ -100,14 +100,14 @@
                 "residuals": [{"expression": "const", "value": {"type": ["Bool"], "value": true}}, {"expression": "const", "value": {"type": ["Bool"], "value": true}}],
                 "earlyProbes": [{"builder": 6, "attributes": [1, 2], "type": "lookup"}],
                 "selectivity": 0.262238,
-                "analyze": {"pipeline": 6, "execution-time": 292, "running": false, "tuple-count": 2}
+                "analyze": {"pipeline": 6, "cpu-cycles": 292, "running": false, "tuple-count": 2}
               },
               "keyExpressions": [{"expression": {"value": {"expression": "iuref", "iu": "v11"}}, "iu": ["v14", ["Integer"]]}, {"expression": {"value": {"expression": "iuref", "iu": "v10"}}, "iu": ["v15", ["Integer"]]}],
               "groupingSets": [{"keyIndices": [0, 1], "coreIndices": [0, 1], "behavior": "regular"}],
               "emptyGroups": true,
               "aggExpressions": [{"value": {"expression": "iuref", "iu": "v12"}}],
               "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v16", ["BigNumeric", 38, 2, "nullable"]]}],
-              "analyze": {"pipeline": 3, "execution-time": 183, "memory-bytes": 18432, "running": false, "tuple-count": 2}
+              "analyze": {"pipeline": 3, "cpu-cycles": 183, "memory-bytes": 18432, "running": false, "tuple-count": 2}
             },
             "values": [{"iu": ["v17", ["BigNumeric", 38, 3, "nullable"]], "value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v16"}, "right": {"expression": "const", "value": {"type": ["Numeric", 2, 1], "value": 5}}}}],
             "analyze": {"pipeline": 3, "tuple-count": 2}
@@ -126,7 +126,7 @@
           "debugName": {"classification": "nonsensitive", "value": "supplier"},
           "earlyProbes": [{"builder": 5, "attributes": [0], "type": "lookup"}, {"builder": 3, "attributes": [3], "type": "lookup"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 1, "execution-time": 194, "running": false, "tuple-count": 1}
+          "analyze": {"pipeline": 1, "cpu-cycles": 194, "running": false, "tuple-count": 1}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v18"}, "right": {"expression": "iuref", "iu": "v8"}},
         "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 1}
@@ -134,7 +134,7 @@
       "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v3"}},
       "analyze": {"pipeline": 1, "memory-bytes": 18432, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 25, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 25, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q21-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q21-analyze.plan.json
@@ -58,7 +58,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "nation"},
                   "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "SAUDI ARABIA"}}}],
                   "selectivity": 0.04,
-                  "analyze": {"pipeline": 7, "execution-time": 54, "running": false, "tuple-count": 1}
+                  "analyze": {"pipeline": 7, "cpu-cycles": 54, "running": false, "tuple-count": 1}
                 },
                 "right": {
                   "operator": "tablescan",
@@ -71,7 +71,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "supplier"},
                   "earlyProbes": [{"builder": 8, "attributes": [3], "type": "lookup"}],
                   "selectivity": 1,
-                  "analyze": {"pipeline": 6, "execution-time": 288, "running": false, "tuple-count": 35}
+                  "analyze": {"pipeline": 6, "cpu-cycles": 288, "running": false, "tuple-count": 35}
                 },
                 "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v3"}},
                 "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 35}
@@ -88,7 +88,7 @@
                 "residuals": [{"expression": "comparison", "mode": ">", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v10"}}],
                 "earlyProbes": [{"builder": 7, "attributes": [2], "type": "lookup"}],
                 "selectivity": 0.5,
-                "analyze": {"pipeline": 5, "execution-time": 961, "running": false, "tuple-count": 87}
+                "analyze": {"pipeline": 5, "cpu-cycles": 961, "running": false, "tuple-count": 87}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v5"}, "right": {"expression": "iuref", "iu": "v9"}},
               "analyze": {"pipeline": 5, "memory-bytes": 18432, "tuple-count": 27}
@@ -105,7 +105,7 @@
               "restrictions": [{"attribute": 2, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char1"], "value": 70}}}],
               "earlyProbes": [{"builder": 6, "attributes": [0], "type": "lookup"}],
               "selectivity": 0.570312,
-              "analyze": {"pipeline": 4, "execution-time": 227, "running": false, "tuple-count": 24}
+              "analyze": {"pipeline": 4, "cpu-cycles": 227, "running": false, "tuple-count": 24}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v12"}, "right": {"expression": "iuref", "iu": "v8"}},
             "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 18}
@@ -122,7 +122,7 @@
             "residuals": [{"expression": "comparison", "mode": ">", "left": {"expression": "iuref", "iu": "v17"}, "right": {"expression": "iuref", "iu": "v16"}}],
             "earlyProbes": [{"builder": 5, "attributes": [0], "type": "lookup"}],
             "selectivity": 0.5,
-            "analyze": {"pipeline": 3, "execution-time": 864, "running": false, "tuple-count": 74}
+            "analyze": {"pipeline": 3, "cpu-cycles": 864, "running": false, "tuple-count": 74}
           },
           "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v14"}, "right": {"expression": "iuref", "iu": "v8"}}, {"expression": "comparison", "mode": "<>", "left": {"expression": "iuref", "iu": "v15"}, "right": {"expression": "iuref", "iu": "v9"}}]},
           "analyze": {"pipeline": 3, "memory-bytes": 18440, "tuple-count": 4}
@@ -138,7 +138,7 @@
           "debugName": {"classification": "nonsensitive", "value": "l2"},
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 2, "execution-time": 625, "running": false, "tuple-count": 20}
+          "analyze": {"pipeline": 2, "cpu-cycles": 625, "running": false, "tuple-count": 20}
         },
         "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v18"}, "right": {"expression": "iuref", "iu": "v8"}}, {"expression": "comparison", "mode": "<>", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v9"}}]},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 1}
@@ -147,9 +147,9 @@
       "groupingSets": [{"keyIndices": [0], "coreIndices": [0], "behavior": "regular"}],
       "emptyGroups": false,
       "aggregates": [{"source": 4294967295, "operation": {"aggregate": "count"}, "iu": ["v2", ["BigInt"]]}],
-      "analyze": {"pipeline": 1, "execution-time": 151, "memory-bytes": 18432, "running": false, "tuple-count": 1}
+      "analyze": {"pipeline": 1, "cpu-cycles": 151, "memory-bytes": 18432, "running": false, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 18, "heap-gc-passes": 0, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 18, "heap-gc-passes": 0, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q22-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q22-analyze.plan.json
@@ -43,13 +43,13 @@
               "debugName": {"classification": "nonsensitive", "value": "customer"},
               "restrictions": [{"attribute": 5, "mode": ">", "value": {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 0}}}, {"attribute": 4, "mode": "lambda", "expression": {"expression": "lookup", "input": [{"expression": "substring", "arguments": [{"expression": "iuref", "iu": "v4"}, {"expression": "const", "value": {"type": ["Integer"], "value": 1}}, {"expression": "const", "value": {"type": ["Integer"], "value": 2}}]}], "values": [{"type": ["Varchar"], "value": "13"}, {"type": ["Varchar"], "value": "17"}, {"type": ["Varchar"], "value": "18"}, {"type": ["Varchar"], "value": "23"}, {"type": ["Varchar"], "value": "29"}, {"type": ["Varchar"], "value": "30"}, {"type": ["Varchar"], "value": "31"}], "collates": [null], "modes": ["equals"]}}],
               "selectivity": 0.286822,
-              "analyze": {"pipeline": 4, "execution-time": 311, "running": false, "tuple-count": 37}
+              "analyze": {"pipeline": 4, "cpu-cycles": 311, "running": false, "tuple-count": 37}
             },
             "groupingSets": [{"keyIndices": [], "coreIndices": null, "behavior": "static"}],
             "emptyGroups": true,
             "aggExpressions": [{"value": {"expression": "iuref", "iu": "v5"}}],
             "aggregates": [{"source": 0, "operation": {"aggregate": "avg"}, "iu": ["v6", ["Numeric", 16, 6, "nullable"]]}],
-            "analyze": {"pipeline": 3, "execution-time": 33, "memory-bytes": 0, "running": false, "tuple-count": 1}
+            "analyze": {"pipeline": 3, "cpu-cycles": 33, "memory-bytes": 0, "running": false, "tuple-count": 1}
           },
           "right": {
             "operator": "leftantijoin",
@@ -68,7 +68,7 @@
               "debugName": {"classification": "nonsensitive", "value": "customer"},
               "restrictions": [{"attribute": 4, "mode": "lambda", "expression": {"expression": "lookup", "input": [{"expression": "substring", "arguments": [{"expression": "iuref", "iu": "v8"}, {"expression": "const", "value": {"type": ["Integer"], "value": 1}}, {"expression": "const", "value": {"type": ["Integer"], "value": 2}}]}], "values": [{"type": ["Varchar"], "value": "13"}, {"type": ["Varchar"], "value": "17"}, {"type": ["Varchar"], "value": "18"}, {"type": ["Varchar"], "value": "23"}, {"type": ["Varchar"], "value": "29"}, {"type": ["Varchar"], "value": "30"}, {"type": ["Varchar"], "value": "31"}], "collates": [null], "modes": ["equals"]}}],
               "selectivity": 0.294574,
-              "analyze": {"pipeline": 5, "execution-time": 371, "running": false, "tuple-count": 38}
+              "analyze": {"pipeline": 5, "cpu-cycles": 371, "running": false, "tuple-count": 38}
             },
             "right": {
               "operator": "tablescan",
@@ -82,7 +82,7 @@
               "debugName": {"classification": "nonsensitive", "value": "orders"},
               "earlyProbes": [{"builder": 8, "attributes": [1], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 2, "execution-time": 312, "running": false, "tuple-count": 47}
+              "analyze": {"pipeline": 2, "cpu-cycles": 312, "running": false, "tuple-count": 47}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "iuref", "iu": "v7"}},
             "analyze": {"pipeline": 2, "memory-bytes": 18440, "tuple-count": 1}
@@ -98,9 +98,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v9"}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v3", ["BigNumeric", 38, 2]]}, {"source": 4294967295, "operation": {"aggregate": "count"}, "iu": ["v2", ["BigInt"]]}],
-      "analyze": {"pipeline": 1, "execution-time": 181, "memory-bytes": 18432, "running": false, "tuple-count": 1}
+      "analyze": {"pipeline": 1, "cpu-cycles": 181, "memory-bytes": 18432, "running": false, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 24, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 24, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q3-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q3-analyze.plan.json
@@ -40,7 +40,7 @@
             "debugName": {"classification": "nonsensitive", "value": "customer"},
             "restrictions": [{"attribute": 6, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 10], "value": "BUILDING"}}}],
             "selectivity": 0.224806,
-            "analyze": {"pipeline": 4, "execution-time": 132, "running": false, "tuple-count": 29}
+            "analyze": {"pipeline": 4, "cpu-cycles": 132, "running": false, "tuple-count": 29}
           },
           "right": {
             "operator": "tablescan",
@@ -54,7 +54,7 @@
             "restrictions": [{"attribute": 4, "mode": "<", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449792}}}],
             "earlyProbes": [{"builder": 5, "attributes": [1], "type": "lookup"}],
             "selectivity": 0.585938,
-            "analyze": {"pipeline": 3, "execution-time": 225, "running": false, "tuple-count": 19}
+            "analyze": {"pipeline": 3, "cpu-cycles": 225, "running": false, "tuple-count": 19}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v5"}, "right": {"expression": "iuref", "iu": "v8"}},
           "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 15}
@@ -71,7 +71,7 @@
           "restrictions": [{"attribute": 10, "mode": ">", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449792}}}],
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 0.493007,
-          "analyze": {"pipeline": 2, "execution-time": 439, "running": false, "tuple-count": 36}
+          "analyze": {"pipeline": 2, "cpu-cycles": 439, "running": false, "tuple-count": 36}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v7"}},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 11}
@@ -81,9 +81,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v13"}}, "right": {"expression": "iuref", "iu": "v12"}}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigNumeric", 38, 4]]}],
-      "analyze": {"pipeline": 1, "execution-time": 354, "memory-bytes": 18432, "running": false, "tuple-count": 3}
+      "analyze": {"pipeline": 1, "cpu-cycles": 354, "memory-bytes": 18432, "running": false, "tuple-count": 3}
     },
-    "analyze": {"pipeline": 0, "execution-time": 35, "heap-gc-passes": 0, "memory-bytes": 262168, "running": false, "tuple-count": 3}
+    "analyze": {"pipeline": 0, "cpu-cycles": 35, "heap-gc-passes": 0, "memory-bytes": 262168, "running": false, "tuple-count": 3}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q4-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q4-analyze.plan.json
@@ -33,7 +33,7 @@
           "debugName": {"classification": "nonsensitive", "value": "orders"},
           "restrictions": [{"attribute": 4, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449170}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2449262}}}],
           "selectivity": 0.0390625,
-          "analyze": {"pipeline": 3, "execution-time": 106, "running": false, "tuple-count": 5}
+          "analyze": {"pipeline": 3, "cpu-cycles": 106, "running": false, "tuple-count": 5}
         },
         "right": {
           "operator": "tablescan",
@@ -47,7 +47,7 @@
           "residuals": [{"expression": "comparison", "mode": "<", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v8"}}],
           "earlyProbes": [{"builder": 4, "attributes": [0], "type": "lookup"}],
           "selectivity": 0.5,
-          "analyze": {"pipeline": 2, "execution-time": 894, "running": false, "tuple-count": 21}
+          "analyze": {"pipeline": 2, "cpu-cycles": 894, "running": false, "tuple-count": 21}
         },
         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v3"}},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 5}
@@ -56,9 +56,9 @@
       "groupingSets": [{"keyIndices": [0], "coreIndices": [0], "behavior": "regular"}],
       "emptyGroups": false,
       "aggregates": [{"source": 4294967295, "operation": {"aggregate": "count"}, "iu": ["v2", ["BigInt"]]}],
-      "analyze": {"pipeline": 1, "execution-time": 219, "memory-bytes": 18432, "running": false, "tuple-count": 4}
+      "analyze": {"pipeline": 1, "cpu-cycles": 219, "memory-bytes": 18432, "running": false, "tuple-count": 4}
     },
-    "analyze": {"pipeline": 0, "execution-time": 31, "memory-bytes": 262176, "running": false, "tuple-count": 4}
+    "analyze": {"pipeline": 0, "cpu-cycles": 31, "memory-bytes": 262176, "running": false, "tuple-count": 4}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q5-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q5-analyze.plan.json
@@ -57,7 +57,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "region"},
                   "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "ASIA"}}}],
                   "selectivity": 0.2,
-                  "analyze": {"pipeline": 7, "execution-time": 69, "running": false, "tuple-count": 1}
+                  "analyze": {"pipeline": 7, "cpu-cycles": 69, "running": false, "tuple-count": 1}
                 },
                 "right": {
                   "operator": "tablescan",
@@ -70,7 +70,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "nation"},
                   "earlyProbes": [{"builder": 8, "attributes": [2], "type": "lookup"}],
                   "selectivity": 1,
-                  "analyze": {"pipeline": 6, "execution-time": 167, "running": false, "tuple-count": 5}
+                  "analyze": {"pipeline": 6, "cpu-cycles": 167, "running": false, "tuple-count": 5}
                 },
                 "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v3"}},
                 "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 5}
@@ -86,7 +86,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "customer"},
                 "earlyProbes": [{"builder": 7, "attributes": [3], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 5, "execution-time": 399, "running": false, "tuple-count": 21}
+                "analyze": {"pipeline": 5, "cpu-cycles": 399, "running": false, "tuple-count": 21}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v5"}, "right": {"expression": "iuref", "iu": "v9"}},
               "analyze": {"pipeline": 5, "memory-bytes": 18432, "tuple-count": 21}
@@ -103,7 +103,7 @@
               "restrictions": [{"attribute": 4, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449354}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2449719}}}],
               "earlyProbes": [{"builder": 6, "attributes": [1], "type": "lookup"}],
               "selectivity": 0.304688,
-              "analyze": {"pipeline": 4, "execution-time": 139, "running": false, "tuple-count": 11}
+              "analyze": {"pipeline": 4, "cpu-cycles": 139, "running": false, "tuple-count": 11}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v8"}, "right": {"expression": "iuref", "iu": "v11"}},
             "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 9}
@@ -119,7 +119,7 @@
             "debugName": {"classification": "nonsensitive", "value": "lineitem"},
             "earlyProbes": [{"builder": 5, "attributes": [0], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 3, "execution-time": 911, "running": false, "tuple-count": 44}
+            "analyze": {"pipeline": 3, "cpu-cycles": 911, "running": false, "tuple-count": 44}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v13"}, "right": {"expression": "iuref", "iu": "v10"}},
           "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 34}
@@ -135,7 +135,7 @@
           "debugName": {"classification": "nonsensitive", "value": "supplier"},
           "earlyProbes": [{"builder": 4, "attributes": [0, 3], "type": "minmaxonly"}],
           "selectivity": 1,
-          "analyze": {"pipeline": 2, "execution-time": 1138, "running": false, "tuple-count": 518}
+          "analyze": {"pipeline": 2, "cpu-cycles": 1138, "running": false, "tuple-count": 518}
         },
         "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v14"}, "right": {"expression": "iuref", "iu": "v17"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "iuref", "iu": "v18"}}]},
         "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 1}
@@ -145,9 +145,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "sub", "left": {"expression": "const", "value": {"type": ["Numeric", 1], "value": 1}}, "right": {"expression": "iuref", "iu": "v16"}}, "right": {"expression": "iuref", "iu": "v15"}}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v2", ["BigNumeric", 38, 4]]}],
-      "analyze": {"pipeline": 1, "execution-time": 266, "memory-bytes": 18432, "running": false, "tuple-count": 1}
+      "analyze": {"pipeline": 1, "cpu-cycles": 266, "memory-bytes": 18432, "running": false, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 24, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 24, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q6-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q6-analyze.plan.json
@@ -21,13 +21,13 @@
       "debugName": {"classification": "nonsensitive", "value": "lineitem"},
       "restrictions": [{"attribute": 6, "mode": "[]", "value": {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 5}}, "value2": {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 7}}}, {"attribute": 10, "mode": "[)", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449354}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2449719}}}, {"attribute": 4, "mode": "<", "value": {"expression": "const", "value": {"type": ["Numeric", 12, 2], "value": 2400}}}],
       "selectivity": 0.034965,
-      "analyze": {"pipeline": 1, "execution-time": 124, "running": false, "tuple-count": 20}
+      "analyze": {"pipeline": 1, "cpu-cycles": 124, "running": false, "tuple-count": 20}
     },
     "groupingSets": [{"keyIndices": [], "coreIndices": null, "behavior": "static"}],
     "emptyGroups": true,
     "aggExpressions": [{"value": {"expression": "mul", "left": {"expression": "iuref", "iu": "v3"}, "right": {"expression": "iuref", "iu": "v4"}}}],
     "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v", ["BigNumeric", 38, 4, "nullable"]]}],
-    "analyze": {"pipeline": 0, "execution-time": 14, "memory-bytes": 0, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 14, "memory-bytes": 0, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q7-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q7-analyze.plan.json
@@ -60,7 +60,7 @@
                     "values": [{"name": "n_nationkey", "type": ["Integer"], "iu": ["v5", ["Integer"]]}, {"name": "n_name", "type": ["Char", 25], "iu": ["v6", ["Char", 25]]}, {"name": "n_regionkey", "type": ["Integer"], "iu": null}, {"name": "n_comment", "type": ["Varchar", 152], "iu": null}],
                     "debugName": {"classification": "nonsensitive", "value": "n2"},
                     "selectivity": 1,
-                    "analyze": {"pipeline": 7, "execution-time": 227, "running": false, "tuple-count": 25}
+                    "analyze": {"pipeline": 7, "cpu-cycles": 227, "running": false, "tuple-count": 25}
                   },
                   "right": {
                     "operator": "tablescan",
@@ -72,7 +72,7 @@
                     "values": [{"name": "n_nationkey", "type": ["Integer"], "iu": ["v7", ["Integer"]]}, {"name": "n_name", "type": ["Char", 25], "iu": ["v8", ["Char", 25]]}, {"name": "n_regionkey", "type": ["Integer"], "iu": null}, {"name": "n_comment", "type": ["Varchar", 152], "iu": null}],
                     "debugName": {"classification": "nonsensitive", "value": "n1"},
                     "selectivity": 1,
-                    "analyze": {"pipeline": 6, "execution-time": 1451, "running": false, "tuple-count": 25}
+                    "analyze": {"pipeline": 6, "cpu-cycles": 1451, "running": false, "tuple-count": 25}
                   },
                   "condition": {"expression": "lookup", "input": [{"expression": "iuref", "iu": "v8"}, {"expression": "iuref", "iu": "v6"}], "values": [{"type": ["Char", 25], "value": "FRANCE"}, {"type": ["Char", 25], "value": "GERMANY"}, {"type": ["Char", 25], "value": "GERMANY"}, {"type": ["Char", 25], "value": "FRANCE"}], "collates": [null, null], "modes": ["is", "is"]},
                   "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 2}
@@ -88,7 +88,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "customer"},
                   "earlyProbes": [{"builder": 8, "attributes": [3], "type": "lookup"}],
                   "selectivity": 1,
-                  "analyze": {"pipeline": 5, "execution-time": 266, "running": false, "tuple-count": 12}
+                  "analyze": {"pipeline": 5, "cpu-cycles": 266, "running": false, "tuple-count": 12}
                 },
                 "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v10"}, "right": {"expression": "iuref", "iu": "v5"}},
                 "analyze": {"pipeline": 5, "memory-bytes": 18432, "tuple-count": 12}
@@ -104,7 +104,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "orders"},
                 "earlyProbes": [{"builder": 7, "attributes": [1], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 4, "execution-time": 233, "running": false, "tuple-count": 15}
+                "analyze": {"pipeline": 4, "cpu-cycles": 233, "running": false, "tuple-count": 15}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "iuref", "iu": "v12"}},
               "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 12}
@@ -121,7 +121,7 @@
               "restrictions": [{"attribute": 10, "mode": "[]", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449719}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2450449}}}],
               "earlyProbes": [{"builder": 6, "attributes": [0], "type": "lookup"}],
               "selectivity": 0.421329,
-              "analyze": {"pipeline": 3, "execution-time": 529, "running": false, "tuple-count": 30}
+              "analyze": {"pipeline": 3, "cpu-cycles": 529, "running": false, "tuple-count": 30}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v13"}},
             "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 30}
@@ -137,7 +137,7 @@
             "debugName": {"classification": "nonsensitive", "value": "supplier"},
             "earlyProbes": [{"builder": 5, "attributes": [0, 3], "type": "minmaxonly"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 2, "execution-time": 1190, "running": false, "tuple-count": 518}
+            "analyze": {"pipeline": 2, "cpu-cycles": 1190, "running": false, "tuple-count": 518}
           },
           "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v18"}, "right": {"expression": "iuref", "iu": "v14"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v7"}}]},
           "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 1}
@@ -150,9 +150,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v21"}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v4", ["BigNumeric", 38, 4]]}],
-      "analyze": {"pipeline": 1, "execution-time": 342, "memory-bytes": 18432, "running": false, "tuple-count": 1}
+      "analyze": {"pipeline": 1, "cpu-cycles": 342, "memory-bytes": 18432, "running": false, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 131, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 131, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q8-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q8-analyze.plan.json
@@ -55,7 +55,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "region"},
                   "restrictions": [{"attribute": 1, "mode": "=", "value": {"expression": "const", "value": {"type": ["Char", 25], "value": "AMERICA"}}}],
                   "selectivity": 0.2,
-                  "analyze": {"pipeline": 5, "execution-time": 57, "running": false, "tuple-count": 1}
+                  "analyze": {"pipeline": 5, "cpu-cycles": 57, "running": false, "tuple-count": 1}
                 },
                 "right": {
                   "operator": "join",
@@ -92,7 +92,7 @@
                           "debugName": {"classification": "nonsensitive", "value": "part"},
                           "restrictions": [{"attribute": 4, "mode": "=", "value": {"expression": "const", "value": {"type": ["Varchar", 25], "value": "ECONOMY ANODIZED STEEL"}}}],
                           "selectivity": 0.00562852,
-                          "analyze": {"pipeline": 9, "execution-time": 134, "running": false, "tuple-count": 3}
+                          "analyze": {"pipeline": 9, "cpu-cycles": 134, "running": false, "tuple-count": 3}
                         },
                         "right": {
                           "operator": "tablescan",
@@ -105,7 +105,7 @@
                           "debugName": {"classification": "nonsensitive", "value": "lineitem"},
                           "earlyProbes": [{"builder": 13, "attributes": [1], "type": "lookup"}],
                           "selectivity": 1,
-                          "analyze": {"pipeline": 8, "execution-time": 726, "running": false, "tuple-count": 10}
+                          "analyze": {"pipeline": 8, "cpu-cycles": 726, "running": false, "tuple-count": 10}
                         },
                         "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v5"}, "right": {"expression": "iuref", "iu": "v8"}},
                         "analyze": {"pipeline": 8, "memory-bytes": 18432, "tuple-count": 3}
@@ -122,7 +122,7 @@
                         "restrictions": [{"attribute": 4, "mode": "[]", "value": {"expression": "const", "value": {"type": ["Date"], "value": 2449719}}, "value2": {"expression": "const", "value": {"type": ["Date"], "value": 2450449}}}],
                         "earlyProbes": [{"builder": 12, "attributes": [0], "type": "lookup"}],
                         "selectivity": 0.367188,
-                        "analyze": {"pipeline": 7, "execution-time": 208, "running": false, "tuple-count": 2}
+                        "analyze": {"pipeline": 7, "cpu-cycles": 208, "running": false, "tuple-count": 2}
                       },
                       "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v7"}, "right": {"expression": "iuref", "iu": "v12"}},
                       "analyze": {"pipeline": 7, "memory-bytes": 18432, "tuple-count": 2}
@@ -138,7 +138,7 @@
                       "debugName": {"classification": "nonsensitive", "value": "customer"},
                       "earlyProbes": [{"builder": 11, "attributes": [0], "type": "lookup"}],
                       "selectivity": 1,
-                      "analyze": {"pipeline": 6, "execution-time": 184, "running": false, "tuple-count": 4}
+                      "analyze": {"pipeline": 6, "cpu-cycles": 184, "running": false, "tuple-count": 4}
                     },
                     "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v13"}, "right": {"expression": "iuref", "iu": "v15"}},
                     "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 2}
@@ -154,7 +154,7 @@
                     "debugName": {"classification": "nonsensitive", "value": "n1"},
                     "earlyProbes": [{"builder": 10, "attributes": [0], "type": "lookup"}, {"builder": 8, "attributes": [2], "type": "lookup"}],
                     "selectivity": 1,
-                    "analyze": {"pipeline": 4, "execution-time": 144, "running": false, "tuple-count": 1}
+                    "analyze": {"pipeline": 4, "cpu-cycles": 144, "running": false, "tuple-count": 1}
                   },
                   "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v16"}, "right": {"expression": "iuref", "iu": "v17"}},
                   "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 1}
@@ -173,7 +173,7 @@
                 "debugName": {"classification": "nonsensitive", "value": "supplier"},
                 "earlyProbes": [{"builder": 7, "attributes": [0], "type": "lookup"}],
                 "selectivity": 1,
-                "analyze": {"pipeline": 3, "execution-time": 30, "running": false, "tuple-count": 1}
+                "analyze": {"pipeline": 3, "cpu-cycles": 30, "running": false, "tuple-count": 1}
               },
               "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v9"}},
               "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 1}
@@ -189,7 +189,7 @@
               "debugName": {"classification": "nonsensitive", "value": "n2"},
               "earlyProbes": [{"builder": 6, "attributes": [0], "type": "lookup"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 2, "execution-time": 36, "running": false, "tuple-count": 1}
+              "analyze": {"pipeline": 2, "cpu-cycles": 36, "running": false, "tuple-count": 1}
             },
             "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v20"}, "right": {"expression": "iuref", "iu": "v21"}},
             "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 1}
@@ -202,12 +202,12 @@
         "emptyGroups": false,
         "aggExpressions": [{"value": {"expression": "simplecase", "value": {"expression": "iuref", "iu": "v22"}, "cases": [{"cases": [{"expression": "const", "value": {"type": ["Varchar"], "value": "BRAZIL"}}], "value": {"expression": "iuref", "iu": "v24"}}], "else": {"expression": "const", "value": {"type": ["BigNumeric", 25, 4], "low": 0, "high": 0}}}}, {"value": {"expression": "iuref", "iu": "v24"}}],
         "aggregates": [{"source": 1, "operation": {"aggregate": "sum"}, "iu": ["v25", ["BigNumeric", 38, 4]]}, {"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v26", ["BigNumeric", 38, 4]]}],
-        "analyze": {"pipeline": 1, "execution-time": 280, "memory-bytes": 18432, "running": false, "tuple-count": 1}
+        "analyze": {"pipeline": 1, "cpu-cycles": 280, "memory-bytes": 18432, "running": false, "tuple-count": 1}
       },
       "values": [{"iu": ["v2", ["BigNumeric", 38, 6]], "value": {"expression": "div", "left": {"expression": "iuref", "iu": "v26"}, "right": {"expression": "iuref", "iu": "v25"}}}],
       "analyze": {"pipeline": 1, "tuple-count": 1}
     },
-    "analyze": {"pipeline": 0, "execution-time": 24, "memory-bytes": 262152, "running": false, "tuple-count": 1}
+    "analyze": {"pipeline": 0, "cpu-cycles": 24, "memory-bytes": 262152, "running": false, "tuple-count": 1}
   },
   "analyze": {"error": null, "pipeline": 0}
 }

--- a/standalone-app/examples/hyper/tpch/tpch-q9-analyze.plan.json
+++ b/standalone-app/examples/hyper/tpch/tpch-q9-analyze.plan.json
@@ -48,7 +48,7 @@
                 "values": [{"name": "n_nationkey", "type": ["Integer"], "iu": ["v4", ["Integer"]]}, {"name": "n_name", "type": ["Char", 25], "iu": ["v5", ["Char", 25]]}, {"name": "n_regionkey", "type": ["Integer"], "iu": null}, {"name": "n_comment", "type": ["Varchar", 152], "iu": null}],
                 "debugName": {"classification": "nonsensitive", "value": "nation"},
                 "selectivity": 1,
-                "analyze": {"pipeline": 5, "execution-time": 132, "running": false, "tuple-count": 25}
+                "analyze": {"pipeline": 5, "cpu-cycles": 132, "running": false, "tuple-count": 25}
               },
               "right": {
                 "operator": "join",
@@ -73,7 +73,7 @@
                     "debugName": {"classification": "nonsensitive", "value": "part"},
                     "restrictions": [{"attribute": 1, "mode": "lambda", "expression": {"expression": "like", "arguments": [{"expression": "iuref", "iu": "v7"}, {"expression": "const", "value": {"type": ["Varchar"], "value": "%green%"}}, {"expression": "const", "value": {"type": ["Varchar"], "value": "\\"}}]}}],
                     "selectivity": 0.0525328,
-                    "analyze": {"pipeline": 7, "execution-time": 1278, "running": false, "tuple-count": 28}
+                    "analyze": {"pipeline": 7, "cpu-cycles": 1278, "running": false, "tuple-count": 28}
                   },
                   "right": {
                     "operator": "tablescan",
@@ -86,7 +86,7 @@
                     "debugName": {"classification": "nonsensitive", "value": "partsupp"},
                     "earlyProbes": [{"builder": 10, "attributes": [0], "type": "lookup"}],
                     "selectivity": 1,
-                    "analyze": {"pipeline": 6, "execution-time": 941, "running": false, "tuple-count": 89}
+                    "analyze": {"pipeline": 6, "cpu-cycles": 941, "running": false, "tuple-count": 89}
                   },
                   "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v8"}},
                   "analyze": {"pipeline": 6, "memory-bytes": 18432, "tuple-count": 28}
@@ -102,7 +102,7 @@
                   "debugName": {"classification": "nonsensitive", "value": "supplier"},
                   "earlyProbes": [{"builder": 9, "attributes": [0], "type": "lookup"}],
                   "selectivity": 1,
-                  "analyze": {"pipeline": 4, "execution-time": 1280, "running": false, "tuple-count": 73}
+                  "analyze": {"pipeline": 4, "cpu-cycles": 1280, "running": false, "tuple-count": 73}
                 },
                 "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v9"}},
                 "analyze": {"pipeline": 4, "memory-bytes": 18432, "tuple-count": 28}
@@ -121,7 +121,7 @@
               "debugName": {"classification": "nonsensitive", "value": "lineitem"},
               "earlyProbes": [{"builder": 6, "attributes": [1, 1, 2, 2], "type": "minmaxonly"}],
               "selectivity": 1,
-              "analyze": {"pipeline": 3, "execution-time": 1423, "running": false, "tuple-count": 572}
+              "analyze": {"pipeline": 3, "cpu-cycles": 1423, "running": false, "tuple-count": 572}
             },
             "condition": {"expression": "and", "arguments": [{"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v8"}, "right": {"expression": "iuref", "iu": "v14"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v6"}, "right": {"expression": "iuref", "iu": "v14"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v9"}, "right": {"expression": "iuref", "iu": "v15"}}, {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v11"}, "right": {"expression": "iuref", "iu": "v15"}}]},
             "analyze": {"pipeline": 3, "memory-bytes": 18432, "tuple-count": 28}
@@ -137,7 +137,7 @@
             "debugName": {"classification": "nonsensitive", "value": "orders"},
             "earlyProbes": [{"builder": 5, "attributes": [0], "type": "lookup"}],
             "selectivity": 1,
-            "analyze": {"pipeline": 2, "execution-time": 449, "running": false, "tuple-count": 36}
+            "analyze": {"pipeline": 2, "cpu-cycles": 449, "running": false, "tuple-count": 36}
           },
           "condition": {"expression": "comparison", "mode": "=", "left": {"expression": "iuref", "iu": "v19"}, "right": {"expression": "iuref", "iu": "v13"}},
           "analyze": {"pipeline": 2, "memory-bytes": 18432, "tuple-count": 28}
@@ -150,9 +150,9 @@
       "emptyGroups": false,
       "aggExpressions": [{"value": {"expression": "iuref", "iu": "v22"}}],
       "aggregates": [{"source": 0, "operation": {"aggregate": "sum"}, "iu": ["v3", ["BigNumeric", 38, 4]]}],
-      "analyze": {"pipeline": 1, "execution-time": 255, "memory-bytes": 18432, "running": false, "tuple-count": 27}
+      "analyze": {"pipeline": 1, "cpu-cycles": 255, "memory-bytes": 18432, "running": false, "tuple-count": 27}
     },
-    "analyze": {"pipeline": 0, "execution-time": 89, "memory-bytes": 262360, "running": false, "tuple-count": 27}
+    "analyze": {"pipeline": 0, "cpu-cycles": 89, "memory-bytes": 262360, "running": false, "tuple-count": 27}
   },
   "analyze": {"error": null, "pipeline": 0}
 }


### PR DESCRIPTION
In hyper analyzed query plan, we report "cpu-cycles" & not "execution-time". 
Accordingly, the attribute name has been updated recently in hyper & this PR is going to fix the query graph to use "cpu-cycles" instead of "execution-time" attribute for highlighting operators with higher cpu consumption.