### PR TITLE
Hyper: Fix cardinality misestimation highlighting logic

### DIFF
--- a/query-graphs/src/hyper.ts
+++ b/query-graphs/src/hyper.ts
@@ -282,7 +282,7 @@ function convertHyperNode(rawNode: Json, parentKey, conversionState: ConversionS
                 conversionState.edgeWidths.push({node: convertedNode, width: actualCard});
                 convertedNode.edgeLabel = formatMetric(actualCard) + "/" + formatMetric(estimatedCard);
                 // Highlight significant differences between planned and actual rows
-                if (estimatedCard > actualCard * 10 || actualCard * 10 < estimatedCard) {
+                if (estimatedCard > actualCard * 10 || actualCard > estimatedCard * 10) {
                     convertedNode.edgeClass = "qg-label-highlighted";
                 }
             } else {


### PR DESCRIPTION
The second condition was a duplicate of the first, checking if `estimated > actual*10` twice. Now correctly highlights both overestimations (`est > actual*10`) and underestimations (`actual > est*10`).