### PR TITLE
Remove legacy /upload-form.html and /query-graphs.html URLs from upload-server

### DIFF
--- a/upload-server/README.md
+++ b/upload-server/README.md
@@ -9,7 +9,7 @@ The whole server is a single file, `upload-server.js`.
 
 The server plays two roles, wiring itself to the deployed app:
 
-1. **Entry redirect** — a `GET /` (also the legacy `/upload-form.html` and `/query-graphs.html` paths) redirects to the app's `index.html` with a `?uploadServer=<this-server>/uploads` parameter.
+1. **Entry redirect** — a `GET /` redirects to the app's `index.html` with a `?uploadServer=<this-server>/uploads` parameter.
    From then on, the app knows to upload opened plans here (see the sharing flow in [`standalone-app`](../standalone-app/README.md)).
 2. **Upload endpoint** — a `PUT /uploads` accepts the raw plan body (up to 2 MB), writes it to a file with a random name, and responds with that file's public URL.
    `GET /uploads/<file>` then serves it back, with CORS enabled so the app can fetch it from another origin.

--- a/upload-server/upload-server.js
+++ b/upload-server/upload-server.js
@@ -82,10 +82,6 @@ function forwardToGUI(req, res) {
     guiLogger(`forwarded to ${forwardURL}`);
 }
 app.get("/", forwardToGUI);
-// Common names used previously by the standalone server.
-// Forward them in case somebody bookmarked the old UI.
-app.get("/upload-form.html", forwardToGUI);
-app.get("/query-graphs.html", forwardToGUI);
 
 const server = app.listen(3000, function () {
     const host = server.address().address;


### PR DESCRIPTION
These legacy entry points for the old standalone server are no longer needed. Simplify to use only the root / path for all server entry points.