### PR TITLE
Tableau: Fix logical operator expansion

### DIFF
--- a/query-graphs/src/tableau.ts
+++ b/query-graphs/src/tableau.ts
@@ -22,8 +22,8 @@ function normalizeLogicalOperator(tag: string, clazz?: string) {
     if (tag == "logical-operator") {
         return clazz;
     }
-    if (clazz == "logical-operator" && tag.endsWith("Op")) {
-        return tag.substring(0, tag.length - 2);
+    if (tag.endsWith("Op")) {
+        return clazz == "logical-operator" ? tag.substring(0, tag.length - 2) : tag.substring(0, tag.length - 2);
     }
     return undefined;
 }


### PR DESCRIPTION
Relax normalizeLogicalOperator to recognize any tag ending in 'Op' as a potential logical operator, not just those with class='logical-operator'. This ensures operators like domainOp, aggregateOp, selectOp are placed in expandedChildren and shown by default rather than collapsedChildren.

Fixes rendering of logical-operator-class-domain.xml and similar plans where operators are collapsed by default when they should be expanded.