### PR TITLE
Adopt new toolchain warnings / lints

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import reactPlugin from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
-import {fixupConfigRules, fixupPluginRules, includeIgnoreFile} from "@eslint/compat";
+import {fixupConfigRules, includeIgnoreFile} from "@eslint/compat";
 import globals from "globals";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -26,6 +26,7 @@ export default [
             react: {version: "detect"},
         },
     },
+    reactHooks.configs.flat.recommended,
     {
         files: ["**/*.ts", "**/*.tsx", "**/*.js"],
         languageOptions: {
@@ -38,14 +39,12 @@ export default [
                 },
             },
         },
-        plugins: {
-            "react-hooks": fixupPluginRules(reactHooks),
-        },
         rules: {
             // We don't consider those rules helpful
             "@typescript-eslint/no-empty-function": "off",
             "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-unused-vars": ["error", {vars: "all", argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_"}],
+            "@typescript-eslint/consistent-type-imports": "error",
             // We use `react-jsx` and there `React` does not need to be in scope
             "react/react-in-jsx-scope": "off",
             // The following rules should be enabled, but aren't yet due to legacy code which still needs
@@ -53,8 +52,6 @@ export default [
             "@typescript-eslint/explicit-module-boundary-types": "off",
             "@typescript-eslint/no-explicit-any": "off",
             "no-prototype-builtins": "off",
-            "react-hooks/rules-of-hooks": "error",
-            "react-hooks/exhaustive-deps": "error",
         },
     },
     {

--- a/query-graphs/src/hyper.ts
+++ b/query-graphs/src/hyper.ts
@@ -20,8 +20,10 @@ We transform a Hyper JSON tree into a query-graphs tree using the following heur
 
 */
 
-import {TreeNode, TreeDescription, Crosslink, IconName, allChildren} from "./tree-description";
-import {Json, JsonObject, forceToString, tryToString, formatMetric, hasOwnProperty, tryGetPropertyPath} from "./loader-utils";
+import type {TreeNode, TreeDescription, Crosslink, IconName} from "./tree-description";
+import {allChildren} from "./tree-description";
+import type {Json, JsonObject} from "./loader-utils";
+import {forceToString, tryToString, formatMetric, hasOwnProperty, tryGetPropertyPath} from "./loader-utils";
 
 // A categorical color palette for execution pipelines (the Tableau 20 colors).
 // The ten saturated base hues come first, then their lighter companions, so

--- a/query-graphs/src/json.ts
+++ b/query-graphs/src/json.ts
@@ -7,8 +7,9 @@ Map the JSON tree directly to a D3 tree, without any modifications
 
 */
 
-import {Json, tryToString} from "./loader-utils";
-import {TreeDescription, TreeNode} from "./tree-description";
+import type {Json} from "./loader-utils";
+import {tryToString} from "./loader-utils";
+import type {TreeDescription, TreeNode} from "./tree-description";
 
 function convertChildren(node: Json): TreeNode[] {
     const strRep = tryToString(node);

--- a/query-graphs/src/postgres.ts
+++ b/query-graphs/src/postgres.ts
@@ -8,8 +8,9 @@ This is pretty much the same algorithm as the algorithm for Hyper plans
 */
 
 import * as treeDescription from "./tree-description";
-import {TreeNode, TreeDescription, Crosslink, IconName} from "./tree-description";
-import {assert, Json, tryToString, formatMetric, hasOwnProperty, hasSubOject} from "./loader-utils";
+import type {TreeNode, TreeDescription, Crosslink, IconName} from "./tree-description";
+import type {Json} from "./loader-utils";
+import {assert, tryToString, formatMetric, hasOwnProperty, hasSubOject} from "./loader-utils";
 
 interface UnresolvedCrosslink {
     source: TreeNode;

--- a/query-graphs/src/tableau.ts
+++ b/query-graphs/src/tableau.ts
@@ -10,8 +10,9 @@ already provides us the structure of the rendered tree.
 */
 
 // Require node modules
-import {IconName, TreeDescription, TreeNode} from "./tree-description";
-import {typesafeXMLParse, ParsedXML} from "./xml";
+import type {IconName, TreeDescription, TreeNode} from "./tree-description";
+import type {ParsedXML} from "./xml";
+import {typesafeXMLParse} from "./xml";
 
 function normalizeLogicalOperator(tag: string, clazz?: string) {
     // Logical queries

--- a/query-graphs/src/ui/ColoredEdge.tsx
+++ b/query-graphs/src/ui/ColoredEdge.tsx
@@ -1,4 +1,5 @@
-import {BaseEdge, EdgeProps, getBezierPath} from "reactflow";
+import type {EdgeProps} from "reactflow";
+import {BaseEdge, getBezierPath} from "reactflow";
 
 // Data attached to a colored edge.
 export interface ColoredEdgeData {

--- a/query-graphs/src/ui/NodeIcon.tsx
+++ b/query-graphs/src/ui/NodeIcon.tsx
@@ -1,5 +1,5 @@
-import {CSSProperties, SVGAttributes} from "react";
-import {IconName} from "../tree-description";
+import type {CSSProperties, SVGAttributes} from "react";
+import type {IconName} from "../tree-description";
 import "./NodeIcon.css";
 
 interface NodeIconProps {

--- a/query-graphs/src/ui/QueryGraph.tsx
+++ b/query-graphs/src/ui/QueryGraph.tsx
@@ -1,9 +1,12 @@
-import ReactFlow, {MiniMap, Node, Controls, ReactFlowProvider} from "reactflow";
+import type {Node} from "reactflow";
+import ReactFlow, {MiniMap, Controls, ReactFlowProvider} from "reactflow";
 import "reactflow/dist/base.css";
 
 import {layoutTree} from "./tree-layout";
-import {TreeDescription, TreeNode, allChildren, visitTreeNodes} from "../tree-description";
-import {useMemo, useEffect, useRef, ReactNode} from "react";
+import type {TreeDescription, TreeNode} from "../tree-description";
+import {allChildren, visitTreeNodes} from "../tree-description";
+import type {ReactNode} from "react";
+import {useMemo, useEffect, useRef} from "react";
 import {QueryNode} from "./QueryNode";
 import {ColoredEdge} from "./ColoredEdge";
 import {useGraphRenderingStore} from "./store";

--- a/query-graphs/src/ui/QueryNode.tsx
+++ b/query-graphs/src/ui/QueryNode.tsx
@@ -1,7 +1,9 @@
-import {memo, ReactElement, MouseEvent, useCallback, useRef, useEffect, RefObject} from "react";
-import {Handle, NodeProps, Position} from "reactflow";
+import type {ReactElement, MouseEvent, RefObject} from "react";
+import {memo, useCallback, useRef, useEffect} from "react";
+import type {NodeProps} from "reactflow";
+import {Handle, Position} from "reactflow";
 import cc from "classcat";
-import {TreeNode} from "../tree-description";
+import type {TreeNode} from "../tree-description";
 import {NodeIcon} from "./NodeIcon";
 import "./QueryNode.css";
 import {useGraphRenderingStore} from "./store";

--- a/query-graphs/src/ui/d3-flextree.d.ts
+++ b/query-graphs/src/ui/d3-flextree.d.ts
@@ -1,5 +1,5 @@
 declare module "d3-flextree" {
-    import {HierarchyNode, HierarchyPointNode} from "d3-hierarchy";
+    import type {HierarchyNode, HierarchyPointNode} from "d3-hierarchy";
     export interface FlexTreeLayout<Datum> {
         (root: HierarchyNode<Datum>): HierarchyPointNode<Datum>;
         nodeSize(size: (node: HierarchyPointNode<Datum>) => [number, number]): this;

--- a/query-graphs/src/ui/tree-layout.ts
+++ b/query-graphs/src/ui/tree-layout.ts
@@ -1,12 +1,12 @@
 import * as d3flextree from "d3-flextree";
 import * as d3hierarchy from "d3-hierarchy";
 
-import {NodeDimensions} from "./store";
-import * as treeDescription from "../tree-description";
-import {TreeNode, TreeDescription} from "../tree-description";
+import type {NodeDimensions} from "./store";
+import type * as treeDescription from "../tree-description";
+import type {TreeNode, TreeDescription} from "../tree-description";
 import type {Edge, Node} from "reactflow";
 import {assertNotNull} from "../loader-utils";
-import {CSSProperties} from "react";
+import type {CSSProperties} from "react";
 
 interface TreeLayout {
     nodes: Node<TreeNode>[];

--- a/query-graphs/src/xml.ts
+++ b/query-graphs/src/xml.ts
@@ -9,7 +9,7 @@ in the tooltips.
 
 */
 
-import {TreeDescription, TreeNode} from "./tree-description";
+import type {TreeDescription, TreeNode} from "./tree-description";
 
 export interface ParsedXML {
     tag: string;

--- a/standalone-app/src/ErrorBoundary.tsx
+++ b/standalone-app/src/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import {Component, ReactNode} from "react";
+import type {ReactNode} from "react";
+import {Component} from "react";
 
 interface ErrorBoundaryState {
     error?: unknown;

--- a/standalone-app/src/FileOpener.tsx
+++ b/standalone-app/src/FileOpener.tsx
@@ -1,4 +1,5 @@
-import React, {useCallback, useEffect, useMemo, useState} from "react";
+import type React from "react";
+import {useCallback, useEffect, useMemo, useState} from "react";
 
 import "./FileOpener.css";
 import {assert} from "./assert";

--- a/standalone-app/src/QueryGraphsApp.tsx
+++ b/standalone-app/src/QueryGraphsApp.tsx
@@ -62,12 +62,15 @@ export function QueryGraphsApp() {
         setTreeTitle(title);
         setTreeUrl(url.toString());
     };
-    // We keep the displayed tree in sync with the URL parameter.
-    // Once `treeUrl` is cleared, `displayedTree` below hides the stale tree
-    // immediately, without waiting for this effect to reset `tree`.
-    const displayedTree = treeUrl ? tree : undefined;
+    // We keep the displayed tree in sync with the URL parameter
     useEffect(() => {
         if (!treeUrl) {
+            // Resetting `tree` here (rather than deriving it from `treeUrl` at render
+            // time) means the old tree stays on screen for one extra frame after
+            // `treeUrl` clears, until this effect runs. We accept that flicker to
+            // keep `tree` as the single source of truth for what's displayed.
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setTree(undefined);
             return;
         }
         const abortController = new AbortController();
@@ -125,12 +128,12 @@ export function QueryGraphsApp() {
         }
     }, []);
 
-    if (!displayedTree) {
+    if (!tree) {
         return <FileOpener setData={openPickedData} loadStateController={loadStateController} validate={validate} />;
     } else {
         return (
-            <QueryGraph treeDescription={displayedTree}>
-                <TreeLabel title={treeTitle ?? ""} setTitle={setTreeTitle} metadata={displayedTree.metadata} />
+            <QueryGraph treeDescription={tree}>
+                <TreeLabel title={treeTitle ?? ""} setTitle={setTreeTitle} metadata={tree.metadata} />
             </QueryGraph>
         );
     }

--- a/standalone-app/src/QueryGraphsApp.tsx
+++ b/standalone-app/src/QueryGraphsApp.tsx
@@ -1,8 +1,9 @@
 import {useCallback, useEffect, useState} from "react";
 import {useBrowserUrl, useUrlParam} from "./browserUrlHooks";
-import {FileOpener, FileOpenerData, useLoadStateController} from "./FileOpener";
+import type {FileOpenerData} from "./FileOpener";
+import {FileOpener, useLoadStateController} from "./FileOpener";
 import {QueryGraph} from "@tableau/query-graphs/lib/ui/QueryGraph";
-import {TreeDescription} from "@tableau/query-graphs/lib/tree-description";
+import type {TreeDescription} from "@tableau/query-graphs/lib/tree-description";
 import {loadPlan} from "./tree-loader";
 import {tryCreateLocalStorageUrl, isLocalStorageURL, loadLocalStorageURL} from "./LocalStorageUrl";
 import {assert} from "./assert";
@@ -61,10 +62,12 @@ export function QueryGraphsApp() {
         setTreeTitle(title);
         setTreeUrl(url.toString());
     };
-    // We keep the displayed tree in sync with the URL parameter
+    // We keep the displayed tree in sync with the URL parameter.
+    // Once `treeUrl` is cleared, `displayedTree` below hides the stale tree
+    // immediately, without waiting for this effect to reset `tree`.
+    const displayedTree = treeUrl ? tree : undefined;
     useEffect(() => {
         if (!treeUrl) {
-            setTree(undefined);
             return;
         }
         const abortController = new AbortController();
@@ -122,12 +125,12 @@ export function QueryGraphsApp() {
         }
     }, []);
 
-    if (!tree) {
+    if (!displayedTree) {
         return <FileOpener setData={openPickedData} loadStateController={loadStateController} validate={validate} />;
     } else {
         return (
-            <QueryGraph treeDescription={tree}>
-                <TreeLabel title={treeTitle ?? ""} setTitle={setTreeTitle} metadata={tree.metadata} />
+            <QueryGraph treeDescription={displayedTree}>
+                <TreeLabel title={treeTitle ?? ""} setTitle={setTreeTitle} metadata={displayedTree.metadata} />
             </QueryGraph>
         );
     }

--- a/standalone-app/src/TreeLabel.tsx
+++ b/standalone-app/src/TreeLabel.tsx
@@ -1,4 +1,4 @@
-import {ReactElement} from "react";
+import type {ReactElement} from "react";
 import "./TreeLabel.css";
 
 export interface TreeLabelProps {

--- a/standalone-app/src/tree-loader.ts
+++ b/standalone-app/src/tree-loader.ts
@@ -3,7 +3,7 @@ import {loadHyperPlanFromText} from "@tableau/query-graphs/lib/hyper";
 import {loadTableauPlan} from "@tableau/query-graphs/lib/tableau";
 import {loadJsonFromText} from "@tableau/query-graphs/lib/json";
 import {loadXml} from "@tableau/query-graphs/lib/xml";
-import {TreeDescription} from "@tableau/query-graphs/lib/tree-description";
+import type {TreeDescription} from "@tableau/query-graphs/lib/tree-description";
 import {assert} from "./assert";
 
 export function loadPlan(plan: string): TreeDescription {

--- a/standalone-app/tsconfig.json
+++ b/standalone-app/tsconfig.json
@@ -12,6 +12,6 @@
     "include": ["src/**/*"],
     // See https://github.com/webpack/webpack-cli/issues/2458#issuecomment-846635277
     "ts-node": {
-      "compilerOptions": { "module": "commonjs", "rootDir": "." }
+      "compilerOptions": { "module": "commonjs", "rootDir": ".", "verbatimModuleSyntax": false }
     }
   }

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -11,6 +11,8 @@
         "forceConsistentCasingInFileNames": true,
         "incremental": true,
         "moduleResolution": "bundler",
+        "verbatimModuleSyntax": true,
+        "noUncheckedSideEffectImports": true,
         "noEmitOnError": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
Adopt new TS 6.0 / ESLint 10 capabilities enabled by the toolchain bump (#149)

- Enable verbatimModuleSyntax and noUncheckedSideEffectImports, now that moduleResolution is "bundler". Split all type-only imports into `import type` via the new @typescript-eslint/consistent-type-imports rule (autofixed). Scope verbatimModuleSyntax off for the ts-node override used to load webpack's *.config.ts files as CommonJS.
- Switch to eslint-plugin-react-hooks's `recommended` flat config, which now bundles the former eslint-plugin-react-compiler rule set instead of just rules-of-hooks/exhaustive-deps.
- Silence the one violation it surfaced: QueryGraphsApp.tsx reset `tree` via setState synchronously inside an effect when treeUrl was cleared, leading to a flicker. For now, I just silenced it. Mid-term, I will have to rethink integration with browser navigation.