### PR TITLE
Add browserslist config to query-graphs and standalone-app

### DIFF
--- a/query-graphs/package.json
+++ b/query-graphs/package.json
@@ -36,6 +36,12 @@
     "lib": "lib/"
   },
   "style": "style/query-graphs.css",
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
+  ],
   "dependencies": {
     "@xyflow/react": "^12.11.3",
     "classcat": "^5.0.4",

--- a/standalone-app/package.json
+++ b/standalone-app/package.json
@@ -21,6 +21,12 @@
   "files": [
     "dist/**"
   ],
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
+  ],
   "devDependencies": {
     "@tableau/query-graphs": "workspace:^",
     "@types/node": "^24.13.3",


### PR DESCRIPTION
Documents the actual supported browser targets (recent evergreen Chrome/Firefox/Safari/Edge), matching the ES2024 output and untranspiled React 19 code already shipped with no polyfills or Babel.