### PR TITLE
Convert CSS to use native nesting

### DIFF
--- a/query-graphs/src/ui/QueryGraph.css
+++ b/query-graphs/src/ui/QueryGraph.css
@@ -1,43 +1,46 @@
-.query-graph .react-flow__pane {
-  background: #fdfdfd;
-}
+.query-graph {
+  & .react-flow__pane {
+    background: #fdfdfd;
+  }
 
-.query-graph .react-flow__handle {
-  background-color: transparent;
-  pointer-events: none;
-}
+  & .react-flow__handle {
+    background-color: transparent;
+    pointer-events: none;
+  }
 
-.query-graph .react-flow__pane,
-.query-graph .react-flow__edge,
-.query-graph .react-flow__node {
-  cursor: default;
-}
+  & .react-flow__pane,
+  & .react-flow__edge,
+  & .react-flow__node {
+    cursor: default;
+  }
 
-.query-graph .react-flow__edge-textbg {
-  opacity: .7;
-  fill: white;
-  stroke: #777;
-}
+  & .react-flow__edge-textbg {
+    opacity: .7;
+    fill: white;
+    stroke: #777;
+  }
 
-.query-graph .react-flow__edge-text {
-  font-size: .6em;
-}
+  & .react-flow__edge-text {
+    font-size: .6em;
+  }
 
-.query-graph .react-flow__edge.qg-label-highlighted .react-flow__edge-text {
-  fill: hsl(309, 84%, 36%);
-}
+  & .react-flow__edge.qg-label-highlighted .react-flow__edge-text {
+    fill: hsl(309, 84%, 36%);
+  }
 
+  & .react-flow__edge.qg-crosslink {
+    & .react-flow__edge-path {
+      stroke: #ccc;
+      stroke-dasharray: 4 4;
+      transition-property: stroke, stroke-width, stroke-dasharray;
+      transition-duration: .5s;
+    }
 
-.query-graph .react-flow__edge.qg-crosslink .react-flow__edge-path {
-  stroke: #ccc;
-  stroke-dasharray: 4 4;
-  transition-property: stroke, stroke-width, stroke-dasharray;
-  transition-duration: .5s;
-}
-
-.query-graph .react-flow__edge.qg-crosslink:hover .react-flow__edge-path,
-.query-graph .react-flow__edge.qg-crosslink:focus .react-flow__edge-path {
-  stroke: hsl(309, 84%, 36%);
-  stroke-width: 1.5px;
-  stroke-dasharray: 6 2;
+    &:hover .react-flow__edge-path,
+    &:focus .react-flow__edge-path {
+      stroke: hsl(309, 84%, 36%);
+      stroke-width: 1.5px;
+      stroke-dasharray: 6 2;
+    }
+  }
 }

--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -5,16 +5,18 @@
     margin: -.3em -.5em;
     transition-property: border-color, background-color;
     transition-duration: 0.2s;
-}
-.qg-graph-node.qg-no-props {
-    cursor: default;
-}
-.qg-graph-node.qg-collapsed:hover,
-.qg-graph-node.qg-expanded {
-    cursor: pointer;
-    background: white;
-    border-color: hsl(0,0%, 80%);
-    box-shadow: 1px 2px 5px hsl(0,0%,90%);
+
+    &.qg-no-props {
+        cursor: default;
+    }
+
+    &.qg-collapsed:hover,
+    &.qg-expanded {
+        cursor: pointer;
+        background: white;
+        border-color: hsl(0,0%, 80%);
+        box-shadow: 1px 2px 5px hsl(0,0%,90%);
+    }
 }
 
 .query-graph .react-flow__handle.qg-subtree-handle {
@@ -30,17 +32,17 @@
     pointer-events: all;
     transition-property: background-color;
     transition-duration: 0.2s;
-}
 
-.query-graph .react-flow__handle.qg-subtree-handle.qg-collapsed {
-    opacity: 0;
+    &.qg-collapsed {
+        opacity: 0;
+    }
+
+    &:hover {
+        background: hsl(0,0%,70%);
+    }
 }
 .query-graph .react-flow__node-querynode:hover .react-flow__handle.qg-subtree-handle {
     opacity: 1;
-}
-
-.query-graph .react-flow__handle.qg-subtree-handle:hover {
-    background: hsl(0,0%,70%);
 }
 
 .qg-graph-node-head {
@@ -97,10 +99,11 @@
     overflow: hidden;
     transition-property: max-width, max-height;
     transition-duration: .2s;
-}
-.qg-graph-node.qg-expanded .qg-graph-node-body-wrapper {
-    max-width: 30em;
-    max-height: 20em;
+
+    .qg-graph-node.qg-expanded & {
+        max-width: 30em;
+        max-height: 20em;
+    }
 }
 .qg-graph-node-body {
     width: max-content;
@@ -108,9 +111,10 @@
     overflow: auto;
     max-width: 30em;
     max-height: 20em;
-}
-.qg-graph-node.qg-expanded .qg-graph-node-body {
-    padding-bottom: 0.6em;
+
+    .qg-graph-node.qg-expanded & {
+        padding-bottom: 0.6em;
+    }
 }
 
 .qg-prop-name {

--- a/standalone-app/src/FileOpener.css
+++ b/standalone-app/src/FileOpener.css
@@ -5,22 +5,22 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-}
 
-.file-selection-page .logo {
-    width: 1.5em;
-    margin-right: .5em;
-}
+    & .logo {
+        width: 1.5em;
+        margin-right: .5em;
+    }
 
-.file-selection-page .caption {
-    margin-top: 2em;
-    font-size: 2em;
-    margin-bottom: .5em;
-}
+    & .caption {
+        margin-top: 2em;
+        font-size: 2em;
+        margin-bottom: .5em;
+    }
 
-.file-selection-page .subcaption {
-    font-size: 1.5em;
-    margin-bottom: .5em;
+    & .subcaption {
+        font-size: 1.5em;
+        margin-bottom: .5em;
+    }
 }
 
 .file-selection-page-content {
@@ -40,10 +40,10 @@
     font-size: 0.9em;
     text-align: center;
     color: gray;
-}
 
-.github-link a {
-    color: gray;
+    & a {
+        color: gray;
+    }
 }
 
 /* Hinted text area */
@@ -55,25 +55,25 @@
     border-radius: var(--border-radius);
     overflow: hidden;
     box-shadow: 1px 2px 5px hsl(0,0%,90%);
-}
 
-.hinted-textarea > textarea {
-    resize: vertical;
-    border: none;
-    padding: 0.3em;
-}
+    & > textarea {
+        resize: vertical;
+        border: none;
+        padding: 0.3em;
 
-.hinted-textarea > textarea:focus {
-    outline: none;
-}
+        &:focus {
+            outline: none;
+        }
+    }
 
-.hinted-textarea > .textarea-hint {
-    background: white;
-    border-top: 1px solid #666;
-    border-color: hsl(0,0%, 80%);
-    padding: 0.4em;
-    color: #555;
-    font-size: .8em;
+    & > .textarea-hint {
+        background: white;
+        border-top: 1px solid #666;
+        border-color: hsl(0,0%, 80%);
+        padding: 0.4em;
+        color: #555;
+        font-size: .8em;
+    }
 }
 
 /* Error message */

--- a/standalone-app/src/TreeLabel.css
+++ b/standalone-app/src/TreeLabel.css
@@ -5,10 +5,10 @@
     field-sizing: content;
     min-width: 10em;
     border: none;
-}
 
-.graph-title:hover {
-    background: #ffeded;
+    &:hover {
+        background: #ffeded;
+    }
 }
 
 .graph-metadata {

--- a/standalone-app/src/index.css
+++ b/standalone-app/src/index.css
@@ -16,9 +16,10 @@ body, html, .main-app-container {
 .span-link {
     color: #5c8aff;
     cursor: pointer;
-}
 
-.span-link:hover, span-link:focus {
-    color: #2965ff;
-    text-decoration: underline;
+    &:hover,
+    &:focus {
+        color: #2965ff;
+        text-decoration: underline;
+    }
 }


### PR DESCRIPTION
Nested CSS is supported natively in all relevant browser since 2023:
- Chrome/Edge: 112 (April 2023)
- Firefox: 117 (August 2023)
- Safari: 17.2 (December 2023)

This commit adopts nested CSS, since it is more readable / less error-prone.

As a side effect, fixes a typo in index.css where `.span-link:focus` was missing its leading dot, so the focus style never applied.