### PR TITLE
Move format loaders into query-graphs/src/loaders/

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -28,7 +28,7 @@ The core abstraction connecting the two halves is `TreeDescription`, the format-
 ```mermaid
 flowchart TD
     text["Plan text (JSON / XML)"] --> dispatch["loadPlan()<br/>(standalone-app/tree-loader.ts)"]
-    dispatch -->|tries each loader| loaders["Format loaders<br/>hyper · postgres · tableau · json · xml<br/>(query-graphs/src)"]
+    dispatch -->|tries each loader| loaders["Format loaders<br/>hyper · postgres · tableau · json · xml<br/>(query-graphs/src/loaders)"]
     loaders --> td["TreeDescription<br/>(format-independent tree model)"]
     td --> layout["layoutTree()<br/>(d3-flextree layout)"]
     layout --> render["QueryGraph<br/>(react-flow rendering)"]
@@ -36,7 +36,7 @@ flowchart TD
 ```
 
 1. The app hands the raw text to `loadPlan` (`standalone-app/src/tree-loader.ts`), which tries each loader in turn and keeps the first that succeeds.
-2. The winning loader (e.g. `query-graphs/src/hyper.ts`) transforms the source structure into a `TreeDescription`.
+2. The winning loader (e.g. `query-graphs/src/loaders/hyper.ts`) transforms the source structure into a `TreeDescription`.
    This is where format-specific knowledge lives: how to name nodes, which children to show or collapse, which icon to use, how to label edges.
 3. `layoutTree` (`query-graphs/src/ui/tree-layout.ts`) assigns positions using `d3-flextree`, driven by the measured on-screen size of each node.
 4. `QueryGraph` (`query-graphs/src/ui/QueryGraph.tsx`) renders the positioned tree with react-flow, and a Zustand store tracks interaction state such as which nodes are expanded.

--- a/docs/PlanFormatsAndLoaders.md
+++ b/docs/PlanFormatsAndLoaders.md
@@ -6,7 +6,7 @@ Everything downstream (layout, rendering, interaction) is shared across formats.
 
 ## Supported Formats
 
-| Format | Loader (`query-graphs/src`) | Source shape | How it is obtained |
+| Format | Loader (`query-graphs/src/loaders`) | Source shape | How it is obtained |
 | --- | --- | --- | --- |
 | Postgres | `postgres.ts` | JSON | `EXPLAIN (FORMAT JSON)`, ideally with `ANALYZE` |
 | Hyper | `hyper.ts` | JSON | Hyper's `EXPLAIN (FORMAT JSON)`, e.g. via HyperAPI |
@@ -37,7 +37,7 @@ The generic `json`/`xml` loaders come last so a recognized format always wins ov
 To add support for another database's plans:
 
 1. **Write the loader.**
-   Add `query-graphs/src/<db>.ts` exporting a `load<Db>FromText(text: string): TreeDescription`.
+   Add `query-graphs/src/loaders/<db>.ts` exporting a `load<Db>FromText(text: string): TreeDescription`.
    Parse the text, then recursively convert each source node into a `TreeNode`: set `name`, pick an `icon` from the `IconName` union, put scalar attributes into `properties` (shown in the tooltip), and put real children into `children`/`collapsedChildren`.
    Use `hyper.ts` as the reference implementation and reuse the helpers in `loader-utils.ts`.
    Throw an `Error` when the input is not your format, so dispatch can fall through to the next loader.
@@ -46,7 +46,7 @@ To add support for another database's plans:
    If the format comes from a database that [`plan-dumper`](../plan-dumper/README.md) can drive, add a query there so the example can be regenerated instead of hand-maintained.
 4. **Verify** by loading the example in the app; see [`plan-dumper`](../plan-dumper/README.md) for the end-to-end workflow.
 
-The same loaders are exported from the published library (`@tableau/query-graphs/lib/<db>`), so a new format is immediately available to embedders too.
+The same loaders are exported from the published library (`@tableau/query-graphs/lib/loaders/<db>`), so a new format is immediately available to embedders too.
 
 ## Writing a Permissive Loader
 

--- a/query-graphs/README.md
+++ b/query-graphs/README.md
@@ -9,7 +9,7 @@ To see changes in a running UI, rebuild the library and use the app's dev server
 The library provides:
 
 * **The tree model** — `TreeDescription` and `TreeNode` (`src/tree-description.ts`), the format-independent contract between loaders and the renderer.
-* **Format loaders** — `hyper.ts`, `postgres.ts`, `tableau.ts`, and the generic `json.ts`/`xml.ts` fallbacks (`src/`), each turning plan text into a `TreeDescription`.
+* **Format loaders** — `hyper.ts`, `postgres.ts`, `tableau.ts`, and the generic `json.ts`/`xml.ts` fallbacks (`src/loaders/`), each turning plan text into a `TreeDescription`.
 * **The renderer** — lays out and draws the tree; in `src/ui/`.
 * **Interaction state** — a Zustand store (`src/ui/store.ts`) tracking the graph state (expanded nodes, the measured node sizes, ...).
 
@@ -41,7 +41,7 @@ The `hyper.ts` loader is the richest reference:
 * It enforces a meaningful child order (`input`/`left`/`right`/… before alphabetical) so a join's inputs read left-to-right.
 * It converts in two passes: first build the tree, then post-process to resolve crosslinks, compute edge widths, and color nodes by runtime.
 
-Shared parsing/formatting helpers live in `loader-utils.ts` (`tryToString`, `forceToString`, `formatMetric`, `tryGetPropertyPath`, the `Json` type, `assert`).
+Shared parsing/formatting helpers live in `loader-utils.ts` (`tryToString`, `forceToString`, `formatMetric`, `tryGetPropertyPath`, the `Json` type).
 
 The library intentionally exposes low-level loaders (`json`, `xml`) as generic fallbacks so that even an unrecognized plan renders as *something* rather than an error.
 
@@ -101,7 +101,7 @@ Install `@tableau/query-graphs`, then combine a loader with the `QueryGraph` com
 
 ```tsx
 import {QueryGraph} from "@tableau/query-graphs/lib/ui/QueryGraph";
-import {loadHyperPlanFromText} from "@tableau/query-graphs/lib/hyper";
+import {loadHyperPlanFromText} from "@tableau/query-graphs/lib/loaders/hyper";
 
 function MyPlanViewer({planText}: {planText: string}) {
     const tree = loadHyperPlanFromText(planText);

--- a/query-graphs/package.json
+++ b/query-graphs/package.json
@@ -28,8 +28,8 @@
   ],
   "license": "MIT",
   "files": [
-    "lib/*.js",
-    "lib/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.d.ts",
     "style/*.*"
   ],
   "directories": {

--- a/query-graphs/src/assert.ts
+++ b/query-graphs/src/assert.ts
@@ -1,0 +1,12 @@
+export function assert(value: boolean, errorMsg = "Assertion violated"): asserts value {
+    if (!value) {
+        // eslint-disable-next-line no-debugger
+        debugger;
+        throw new Error(errorMsg);
+    }
+}
+
+export function assertNotNull<T>(v: T | null | undefined): asserts v is T {
+    assert(v !== null, "Unexpected null value");
+    assert(v !== undefined, "Unexpected undefined value");
+}

--- a/query-graphs/src/loaders/hyper.ts
+++ b/query-graphs/src/loaders/hyper.ts
@@ -20,8 +20,8 @@ We transform a Hyper JSON tree into a query-graphs tree using the following heur
 
 */
 
-import type {TreeNode, TreeDescription, Crosslink, IconName} from "./tree-description";
-import {allChildren} from "./tree-description";
+import type {TreeNode, TreeDescription, Crosslink, IconName} from "../tree-description";
+import {allChildren} from "../tree-description";
 import type {Json, JsonObject} from "./loader-utils";
 import {forceToString, tryToString, formatMetric, hasOwnProperty, tryGetPropertyPath} from "./loader-utils";
 

--- a/query-graphs/src/loaders/json.ts
+++ b/query-graphs/src/loaders/json.ts
@@ -9,7 +9,7 @@ Map the JSON tree directly to a D3 tree, without any modifications
 
 import type {Json} from "./loader-utils";
 import {tryToString} from "./loader-utils";
-import type {TreeDescription, TreeNode} from "./tree-description";
+import type {TreeDescription, TreeNode} from "../tree-description";
 
 function convertChildren(node: Json): TreeNode[] {
     const strRep = tryToString(node);

--- a/query-graphs/src/loaders/loader-utils.ts
+++ b/query-graphs/src/loaders/loader-utils.ts
@@ -84,16 +84,3 @@ export function formatMetric(x: number): string {
     }
     return x.toFixed(0) + sizes[idx];
 }
-
-export function assert(value: boolean, errorMsg = "Assertion violated"): asserts value {
-    if (!value) {
-        // eslint-disable-next-line no-debugger
-        debugger;
-        throw new Error(errorMsg);
-    }
-}
-
-export function assertNotNull<T>(v: T | null | undefined): asserts v is T {
-    assert(v !== null, "Unexpected null value");
-    assert(v !== undefined, "Unexpected undefined value");
-}

--- a/query-graphs/src/loaders/postgres.ts
+++ b/query-graphs/src/loaders/postgres.ts
@@ -7,10 +7,11 @@ This is pretty much the same algorithm as the algorithm for Hyper plans
 
 */
 
-import * as treeDescription from "./tree-description";
-import type {TreeNode, TreeDescription, Crosslink, IconName} from "./tree-description";
+import * as treeDescription from "../tree-description";
+import type {TreeNode, TreeDescription, Crosslink, IconName} from "../tree-description";
 import type {Json} from "./loader-utils";
-import {assert, tryToString, formatMetric, hasOwnProperty, hasSubOject} from "./loader-utils";
+import {tryToString, formatMetric, hasOwnProperty, hasSubOject} from "./loader-utils";
+import {assert} from "../assert";
 
 interface UnresolvedCrosslink {
     source: TreeNode;

--- a/query-graphs/src/loaders/tableau.ts
+++ b/query-graphs/src/loaders/tableau.ts
@@ -10,7 +10,7 @@ already provides us the structure of the rendered tree.
 */
 
 // Require node modules
-import type {IconName, TreeDescription, TreeNode} from "./tree-description";
+import type {IconName, TreeDescription, TreeNode} from "../tree-description";
 import type {ParsedXML} from "./xml";
 import {typesafeXMLParse} from "./xml";
 

--- a/query-graphs/src/loaders/xml.ts
+++ b/query-graphs/src/loaders/xml.ts
@@ -9,7 +9,7 @@ in the tooltips.
 
 */
 
-import type {TreeDescription, TreeNode} from "./tree-description";
+import type {TreeDescription, TreeNode} from "../tree-description";
 
 export interface ParsedXML {
     tag: string;

--- a/query-graphs/src/ui/QueryNode.tsx
+++ b/query-graphs/src/ui/QueryNode.tsx
@@ -7,7 +7,7 @@ import type {TreeNode} from "../tree-description";
 import {NodeIcon} from "./NodeIcon";
 import "./QueryNode.css";
 import {useGraphRenderingStore} from "./store";
-import {assert} from "../loader-utils";
+import {assert} from "../assert";
 
 type NodeData = TreeNode & {resizeObserver: ResizeObserver};
 

--- a/query-graphs/src/ui/tree-layout.ts
+++ b/query-graphs/src/ui/tree-layout.ts
@@ -7,7 +7,7 @@ import type {TreeNode, TreeDescription} from "../tree-description";
 import type {Edge} from "@xyflow/react";
 import type {QueryGraphNode} from "./QueryNode";
 import type {ColoredGraphEdge} from "./ColoredEdge";
-import {assertNotNull} from "../loader-utils";
+import {assertNotNull} from "../assert";
 import type {CSSProperties} from "react";
 
 // Crosslinks have no `type`/`data` of their own, so they stay plain `Edge`s.

--- a/standalone-app/src/tree-loader.ts
+++ b/standalone-app/src/tree-loader.ts
@@ -1,8 +1,8 @@
-import {loadPostgresPlanFromText} from "@tableau/query-graphs/lib/postgres";
-import {loadHyperPlanFromText} from "@tableau/query-graphs/lib/hyper";
-import {loadTableauPlan} from "@tableau/query-graphs/lib/tableau";
-import {loadJsonFromText} from "@tableau/query-graphs/lib/json";
-import {loadXml} from "@tableau/query-graphs/lib/xml";
+import {loadPostgresPlanFromText} from "@tableau/query-graphs/lib/loaders/postgres";
+import {loadHyperPlanFromText} from "@tableau/query-graphs/lib/loaders/hyper";
+import {loadTableauPlan} from "@tableau/query-graphs/lib/loaders/tableau";
+import {loadJsonFromText} from "@tableau/query-graphs/lib/loaders/json";
+import {loadXml} from "@tableau/query-graphs/lib/loaders/xml";
 import type {TreeDescription} from "@tableau/query-graphs/lib/tree-description";
 import {assert} from "./assert";
 


### PR DESCRIPTION
I am planning to add a couple more loaders. In preparation for that, move all loaders into the src/loaders/ subdirectory, so they are separated from other files.

Also fix query-graphs/package.json's `files` glob (`lib/*.js` -> `lib/**/*.js`), which only matched top-level lib/ files and silently dropped lib/ui/ and now lib/loaders/ from the published npm package.