### PR TITLE
Mark `*.plan.json` files as generated for GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.plan.json linguist-generated


### PR DESCRIPTION
Collapses generated plan fixtures behind "Load diff" in PRs and excludes them from language stats.