### PR TITLE
Tighten pipeline colour-bar spacing to outgoing edges

### DIFF
--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -23,7 +23,8 @@
     font-size: .7em;
     width: 1em;
     height: 1em;
-    bottom: -.8em;
+    /* Sit below the colour bar instead of overlapping it. */
+    bottom: -1.15em;
     line-height: 1em;
     text-align: center;
     border-radius: 0.5em;
@@ -70,8 +71,6 @@
 }
 .qg-color-bar-below {
     margin-top: 4px;
-    /* Keep the bar above the subtree +/- handle at the bottom of the node. */
-    margin-bottom: 1em;
 }
 .qg-color-bar-seg {
     flex: 1 1 0;

--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -23,8 +23,7 @@
     font-size: .7em;
     width: 1em;
     height: 1em;
-    /* Sit below the colour bar instead of overlapping it. */
-    bottom: -1.15em;
+    bottom: -.8em;
     line-height: 1em;
     text-align: center;
     border-radius: 0.5em;
@@ -71,6 +70,10 @@
 }
 .qg-color-bar-below {
     margin-top: 4px;
+}
+.query-graph .react-flow__node-querynode:hover .qg-color-bar-below,
+.qg-graph-node.qg-expanded .qg-color-bar-below {
+    margin-bottom: 0.8em;
 }
 .qg-color-bar-seg {
     flex: 1 1 0;

--- a/query-graphs/src/ui/QueryNode.tsx
+++ b/query-graphs/src/ui/QueryNode.tsx
@@ -99,13 +99,14 @@ function QueryNode({data, id}: NodeProps<QueryGraphNode>) {
                     <div className="qg-graph-node-label" style={{background: data.nodeColor}}>
                         {data.name}
                     </div>
+                    {expanded ? null : colorBar(data.barsBelow, "below")}
                 </div>
                 <div className="qg-graph-node-body-wrapper nowheel">
                     <div ref={bodyRef} className="qg-graph-node-body">
                         {children}
                     </div>
                 </div>
-                {colorBar(data.barsBelow, "below")}
+                {expanded ? colorBar(data.barsBelow, "below") : null}
             </div>
             <Handle type="source" position={Position.Bottom} className={handleClassName} onClick={onSubtreeHandleClick}>
                 {hasSubtree ? (subtreeExpanded ? "-" : "+") : ""}


### PR DESCRIPTION
## Summary
- The 1em margin under every below-bar (added so the subtree +/- would not sit on the bar) left a large gap between operators and the edges below them.
- Drop that margin and sit the subtree handle slightly lower (`bottom: -1.15em`) so the + still clears the bar without stretching the node.

## Test plan
- [ ] Open `examples.html` forkshare / materialized / unionall / magicunnesting pipeline plans
- [ ] Edges should sit close under the lower colour bars
- [ ] Hover a node with collapsed children: the +/- handle should not overlap the bar
- [ ] Expand a node: the lower bar should still sit after the properties