### PR TITLE
Pretty-print Postgres JSON plans

### DIFF
--- a/plan-dumper/dump-plans.py
+++ b/plan-dumper/dump-plans.py
@@ -108,7 +108,7 @@ with psycopg2.connect("port=5432") as conn:
         with conn.cursor() as cur:
             cur.execute(explain + sql)
             records = cur.fetchall()
-            return json.dumps(records[0][0])
+            return json.dumps(records[0][0], indent=2)
 
     dump_plans("postgres", exec_postgres, get_postgres_plan)
 

--- a/standalone-app/examples/postgres/cte-analyze.plan.json
+++ b/standalone-app/examples/postgres/cte-analyze.plan.json
@@ -1,1 +1,131 @@
-[{"Plan": {"Node Type": "Append", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 16.5, "Total Cost": 26.5, "Plan Rows": 400, "Plan Width": 68, "Actual Startup Time": 0.213, "Actual Total Time": 0.313, "Actual Rows": 256, "Actual Loops": 1, "Subplans Removed": 0, "Plans": [{"Node Type": "Aggregate", "Strategy": "Hashed", "Partial Mode": "Simple", "Parent Relationship": "InitPlan", "Subplan Name": "CTE cte", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.5, "Total Cost": 16.5, "Plan Rows": 200, "Plan Width": 68, "Actual Startup Time": 0.212, "Actual Total Time": 0.26, "Actual Rows": 128, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "sum(lineitem.l_quantity)", "avg(lineitem.l_extendedprice)"], "Group Key": ["lineitem.l_orderkey"], "Planned Partitions": 0, "HashAgg Batches": 1, "Peak Memory Usage": 160, "Disk Usage": 0, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 36, "Actual Startup Time": 0.007, "Actual Total Time": 0.042, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"]}]}, {"Node Type": "CTE Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "CTE Name": "cte", "Alias": "cte", "Startup Cost": 0.0, "Total Cost": 4.0, "Plan Rows": 200, "Plan Width": 68, "Actual Startup Time": 0.213, "Actual Total Time": 0.29, "Actual Rows": 128, "Actual Loops": 1, "Output": ["cte.l_orderkey", "cte.sum", "cte.avg"]}, {"Node Type": "CTE Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "CTE Name": "cte", "Alias": "cte_1", "Startup Cost": 0.0, "Total Cost": 4.0, "Plan Rows": 200, "Plan Width": 68, "Actual Startup Time": 0.0, "Actual Total Time": 0.01, "Actual Rows": 128, "Actual Loops": 1, "Output": ["cte_1.l_orderkey", "cte_1.sum", "cte_1.avg"]}]}, "Planning Time": 0.194, "Triggers": [], "Execution Time": 0.359}]
+[
+  {
+    "Plan": {
+      "Node Type": "Append",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 16.5,
+      "Total Cost": 26.5,
+      "Plan Rows": 400,
+      "Plan Width": 68,
+      "Actual Startup Time": 0.229,
+      "Actual Total Time": 0.342,
+      "Actual Rows": 256,
+      "Actual Loops": 1,
+      "Subplans Removed": 0,
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Hashed",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "InitPlan",
+          "Subplan Name": "CTE cte",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 13.5,
+          "Total Cost": 16.5,
+          "Plan Rows": 200,
+          "Plan Width": 68,
+          "Actual Startup Time": 0.228,
+          "Actual Total Time": 0.281,
+          "Actual Rows": 128,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_orderkey",
+            "sum(lineitem.l_quantity)",
+            "avg(lineitem.l_extendedprice)"
+          ],
+          "Group Key": [
+            "lineitem.l_orderkey"
+          ],
+          "Planned Partitions": 0,
+          "HashAgg Batches": 1,
+          "Peak Memory Usage": 160,
+          "Disk Usage": 0,
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "lineitem",
+              "Schema": "pg_temp",
+              "Alias": "lineitem",
+              "Startup Cost": 0.0,
+              "Total Cost": 12.0,
+              "Plan Rows": 200,
+              "Plan Width": 36,
+              "Actual Startup Time": 0.006,
+              "Actual Total Time": 0.049,
+              "Actual Rows": 572,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_orderkey",
+                "lineitem.l_partkey",
+                "lineitem.l_suppkey",
+                "lineitem.l_linenumber",
+                "lineitem.l_quantity",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount",
+                "lineitem.l_tax",
+                "lineitem.l_returnflag",
+                "lineitem.l_linestatus",
+                "lineitem.l_shipdate",
+                "lineitem.l_commitdate",
+                "lineitem.l_receiptdate",
+                "lineitem.l_shipinstruct",
+                "lineitem.l_shipmode",
+                "lineitem.l_comment"
+              ]
+            }
+          ]
+        },
+        {
+          "Node Type": "CTE Scan",
+          "Parent Relationship": "Member",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "CTE Name": "cte",
+          "Alias": "cte",
+          "Startup Cost": 0.0,
+          "Total Cost": 4.0,
+          "Plan Rows": 200,
+          "Plan Width": 68,
+          "Actual Startup Time": 0.229,
+          "Actual Total Time": 0.306,
+          "Actual Rows": 128,
+          "Actual Loops": 1,
+          "Output": [
+            "cte.l_orderkey",
+            "cte.sum",
+            "cte.avg"
+          ]
+        },
+        {
+          "Node Type": "CTE Scan",
+          "Parent Relationship": "Member",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "CTE Name": "cte",
+          "Alias": "cte_1",
+          "Startup Cost": 0.0,
+          "Total Cost": 4.0,
+          "Plan Rows": 200,
+          "Plan Width": 68,
+          "Actual Startup Time": 0.0,
+          "Actual Total Time": 0.008,
+          "Actual Rows": 128,
+          "Actual Loops": 1,
+          "Output": [
+            "cte_1.l_orderkey",
+            "cte_1.sum",
+            "cte_1.avg"
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.173,
+    "Triggers": [],
+    "Execution Time": 0.476
+  }
+]

--- a/standalone-app/examples/postgres/cte-recursive-analyze.plan.json
+++ b/standalone-app/examples/postgres/cte-recursive-analyze.plan.json
@@ -1,1 +1,82 @@
-[{"Plan": {"Node Type": "CTE Scan", "Parallel Aware": false, "Async Capable": false, "CTE Name": "x", "Alias": "x", "Startup Cost": 2.65, "Total Cost": 3.27, "Plan Rows": 31, "Plan Width": 4, "Actual Startup Time": 0.003, "Actual Total Time": 0.063, "Actual Rows": 100, "Actual Loops": 1, "Output": ["x.i"], "Plans": [{"Node Type": "Recursive Union", "Parent Relationship": "InitPlan", "Subplan Name": "CTE x", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 2.65, "Plan Rows": 31, "Plan Width": 4, "Actual Startup Time": 0.002, "Actual Total Time": 0.048, "Actual Rows": 100, "Actual Loops": 1, "Plans": [{"Node Type": "Result", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 0.01, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.001, "Actual Total Time": 0.001, "Actual Rows": 1, "Actual Loops": 1, "Output": ["1"]}, {"Node Type": "WorkTable Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "CTE Name": "x", "Alias": "x_1", "Startup Cost": 0.0, "Total Cost": 0.23, "Plan Rows": 3, "Plan Width": 4, "Actual Startup Time": 0.0, "Actual Total Time": 0.0, "Actual Rows": 1, "Actual Loops": 100, "Output": ["(x_1.i + 1)"], "Filter": "(x_1.i < 100)", "Rows Removed by Filter": 0}]}]}, "Planning Time": 0.086, "Triggers": [], "Execution Time": 0.098}]
+[
+  {
+    "Plan": {
+      "Node Type": "CTE Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "CTE Name": "x",
+      "Alias": "x",
+      "Startup Cost": 2.65,
+      "Total Cost": 3.27,
+      "Plan Rows": 31,
+      "Plan Width": 4,
+      "Actual Startup Time": 0.003,
+      "Actual Total Time": 0.071,
+      "Actual Rows": 100,
+      "Actual Loops": 1,
+      "Output": [
+        "x.i"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Recursive Union",
+          "Parent Relationship": "InitPlan",
+          "Subplan Name": "CTE x",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 0.0,
+          "Total Cost": 2.65,
+          "Plan Rows": 31,
+          "Plan Width": 4,
+          "Actual Startup Time": 0.002,
+          "Actual Total Time": 0.051,
+          "Actual Rows": 100,
+          "Actual Loops": 1,
+          "Plans": [
+            {
+              "Node Type": "Result",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 0.0,
+              "Total Cost": 0.01,
+              "Plan Rows": 1,
+              "Plan Width": 4,
+              "Actual Startup Time": 0.001,
+              "Actual Total Time": 0.001,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "1"
+              ]
+            },
+            {
+              "Node Type": "WorkTable Scan",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "CTE Name": "x",
+              "Alias": "x_1",
+              "Startup Cost": 0.0,
+              "Total Cost": 0.23,
+              "Plan Rows": 3,
+              "Plan Width": 4,
+              "Actual Startup Time": 0.0,
+              "Actual Total Time": 0.0,
+              "Actual Rows": 1,
+              "Actual Loops": 100,
+              "Output": [
+                "(x_1.i + 1)"
+              ],
+              "Filter": "(x_1.i < 100)",
+              "Rows Removed by Filter": 0
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.8,
+    "Triggers": [],
+    "Execution Time": 0.116
+  }
+]

--- a/standalone-app/examples/postgres/groupby-analyze.plan.json
+++ b/standalone-app/examples/postgres/groupby-analyze.plan.json
@@ -1,1 +1,71 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Hashed", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.5, "Total Cost": 16.5, "Plan Rows": 200, "Plan Width": 72, "Actual Startup Time": 0.175, "Actual Total Time": 0.177, "Actual Rows": 3, "Actual Loops": 1, "Output": ["l_returnflag", "sum(l_quantity)", "avg(l_discount)"], "Group Key": ["lineitem.l_returnflag"], "Planned Partitions": 0, "HashAgg Batches": 1, "Peak Memory Usage": 40, "Disk Usage": 0, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 40, "Actual Startup Time": 0.003, "Actual Total Time": 0.035, "Actual Rows": 572, "Actual Loops": 1, "Output": ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment"]}]}, "Planning Time": 0.039, "Triggers": [], "Execution Time": 0.194}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Hashed",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 13.5,
+      "Total Cost": 16.5,
+      "Plan Rows": 200,
+      "Plan Width": 72,
+      "Actual Startup Time": 0.247,
+      "Actual Total Time": 0.25,
+      "Actual Rows": 3,
+      "Actual Loops": 1,
+      "Output": [
+        "l_returnflag",
+        "sum(l_quantity)",
+        "avg(l_discount)"
+      ],
+      "Group Key": [
+        "lineitem.l_returnflag"
+      ],
+      "Planned Partitions": 0,
+      "HashAgg Batches": 1,
+      "Peak Memory Usage": 40,
+      "Disk Usage": 0,
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Relation Name": "lineitem",
+          "Schema": "pg_temp",
+          "Alias": "lineitem",
+          "Startup Cost": 0.0,
+          "Total Cost": 12.0,
+          "Plan Rows": 200,
+          "Plan Width": 40,
+          "Actual Startup Time": 0.006,
+          "Actual Total Time": 0.05,
+          "Actual Rows": 572,
+          "Actual Loops": 1,
+          "Output": [
+            "l_orderkey",
+            "l_partkey",
+            "l_suppkey",
+            "l_linenumber",
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax",
+            "l_returnflag",
+            "l_linestatus",
+            "l_shipdate",
+            "l_commitdate",
+            "l_receiptdate",
+            "l_shipinstruct",
+            "l_shipmode",
+            "l_comment"
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.058,
+    "Triggers": [],
+    "Execution Time": 0.285
+  }
+]

--- a/standalone-app/examples/postgres/insert.plan.json
+++ b/standalone-app/examples/postgres/insert.plan.json
@@ -1,1 +1,85 @@
-[{"Plan": {"Node Type": "ModifyTable", "Operation": "Insert", "Parallel Aware": false, "Async Capable": false, "Relation Name": "t2", "Schema": "pg_temp", "Alias": "t2", "Startup Cost": 0.0, "Total Cost": 112.03, "Plan Rows": 0, "Plan Width": 0, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 0.0, "Total Cost": 112.03, "Plan Rows": 4080, "Plan Width": 12, "Output": ["(t1.a1 * \"*VALUES*\".column1)", "(t1.b1 * \"*VALUES*\".column1)", "(t1.c1 * \"*VALUES*\".column1)"], "Inner Unique": false, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "t1", "Schema": "pg_temp", "Alias": "t1", "Startup Cost": 0.0, "Total Cost": 30.4, "Plan Rows": 2040, "Plan Width": 12, "Output": ["t1.a1", "t1.b1", "t1.c1"]}, {"Node Type": "Materialize", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 0.04, "Plan Rows": 2, "Plan Width": 4, "Output": ["\"*VALUES*\".column1"], "Plans": [{"Node Type": "Values Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Alias": "*VALUES*", "Startup Cost": 0.0, "Total Cost": 0.03, "Plan Rows": 2, "Plan Width": 4, "Output": ["\"*VALUES*\".column1"]}]}]}]}}]
+[
+  {
+    "Plan": {
+      "Node Type": "ModifyTable",
+      "Operation": "Insert",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Relation Name": "t2",
+      "Schema": "pg_temp",
+      "Alias": "t2",
+      "Startup Cost": 0.0,
+      "Total Cost": 112.03,
+      "Plan Rows": 0,
+      "Plan Width": 0,
+      "Plans": [
+        {
+          "Node Type": "Nested Loop",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Join Type": "Inner",
+          "Startup Cost": 0.0,
+          "Total Cost": 112.03,
+          "Plan Rows": 4080,
+          "Plan Width": 12,
+          "Output": [
+            "(t1.a1 * \"*VALUES*\".column1)",
+            "(t1.b1 * \"*VALUES*\".column1)",
+            "(t1.c1 * \"*VALUES*\".column1)"
+          ],
+          "Inner Unique": false,
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "t1",
+              "Schema": "pg_temp",
+              "Alias": "t1",
+              "Startup Cost": 0.0,
+              "Total Cost": 30.4,
+              "Plan Rows": 2040,
+              "Plan Width": 12,
+              "Output": [
+                "t1.a1",
+                "t1.b1",
+                "t1.c1"
+              ]
+            },
+            {
+              "Node Type": "Materialize",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 0.0,
+              "Total Cost": 0.04,
+              "Plan Rows": 2,
+              "Plan Width": 4,
+              "Output": [
+                "\"*VALUES*\".column1"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Values Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Alias": "*VALUES*",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 0.03,
+                  "Plan Rows": 2,
+                  "Plan Width": 4,
+                  "Output": [
+                    "\"*VALUES*\".column1"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/standalone-app/examples/postgres/magicunnesting-analyze.plan.json
+++ b/standalone-app/examples/postgres/magicunnesting-analyze.plan.json
@@ -1,1 +1,88 @@
-[{"Plan": {"Node Type": "Seq Scan", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 2674.9, "Plan Rows": 210, "Plan Width": 36, "Actual Startup Time": 0.148, "Actual Total Time": 20.954, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_orderkey", "(SubPlan 1)"], "Plans": [{"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.67, "Total Cost": 12.68, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.163, "Actual Total Time": 0.163, "Actual Rows": 1, "Actual Loops": 128, "Output": ["sum(lineitem.l_quantity)"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 16, "Actual Startup Time": 0.001, "Actual Total Time": 0.104, "Actual Rows": 525, "Actual Loops": 128, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "(lineitem.l_extendedprice < orders.o_totalprice)", "Rows Removed by Filter": 47}]}]}, "Planning Time": 0.041, "Triggers": [], "Execution Time": 20.969}]
+[
+  {
+    "Plan": {
+      "Node Type": "Seq Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Relation Name": "orders",
+      "Schema": "pg_temp",
+      "Alias": "orders",
+      "Startup Cost": 0.0,
+      "Total Cost": 2674.9,
+      "Plan Rows": 210,
+      "Plan Width": 36,
+      "Actual Startup Time": 0.179,
+      "Actual Total Time": 20.476,
+      "Actual Rows": 128,
+      "Actual Loops": 1,
+      "Output": [
+        "orders.o_orderkey",
+        "(SubPlan 1)"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Plain",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "SubPlan",
+          "Subplan Name": "SubPlan 1",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 12.67,
+          "Total Cost": 12.68,
+          "Plan Rows": 1,
+          "Plan Width": 32,
+          "Actual Startup Time": 0.159,
+          "Actual Total Time": 0.159,
+          "Actual Rows": 1,
+          "Actual Loops": 128,
+          "Output": [
+            "sum(lineitem.l_quantity)"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "lineitem",
+              "Schema": "pg_temp",
+              "Alias": "lineitem",
+              "Startup Cost": 0.0,
+              "Total Cost": 12.5,
+              "Plan Rows": 67,
+              "Plan Width": 16,
+              "Actual Startup Time": 0.002,
+              "Actual Total Time": 0.111,
+              "Actual Rows": 525,
+              "Actual Loops": 128,
+              "Output": [
+                "lineitem.l_orderkey",
+                "lineitem.l_partkey",
+                "lineitem.l_suppkey",
+                "lineitem.l_linenumber",
+                "lineitem.l_quantity",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount",
+                "lineitem.l_tax",
+                "lineitem.l_returnflag",
+                "lineitem.l_linestatus",
+                "lineitem.l_shipdate",
+                "lineitem.l_commitdate",
+                "lineitem.l_receiptdate",
+                "lineitem.l_shipinstruct",
+                "lineitem.l_shipmode",
+                "lineitem.l_comment"
+              ],
+              "Filter": "(lineitem.l_extendedprice < orders.o_totalprice)",
+              "Rows Removed by Filter": 47
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.062,
+    "Triggers": [],
+    "Execution Time": 20.501
+  }
+]

--- a/standalone-app/examples/postgres/markjoin-analyze.plan.json
+++ b/standalone-app/examples/postgres/markjoin-analyze.plan.json
@@ -1,1 +1,55 @@
-[{"Plan": {"Node Type": "Seq Scan", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 1894.0, "Plan Rows": 150, "Plan Width": 511, "Actual Startup Time": 0.718, "Actual Total Time": 20.632, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment", "EXISTS(SubPlan 1)"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 0.0, "Total Cost": 12.55, "Plan Rows": 1, "Plan Width": 0, "Actual Startup Time": 0.038, "Actual Total Time": 0.038, "Actual Rows": 0, "Actual Loops": 518, "Filter": "((supplier.s_acctbal < partsupp.ps_supplycost) AND (partsupp.ps_suppkey = supplier.s_suppkey))", "Rows Removed by Filter": 494}]}, "Planning Time": 0.101, "Triggers": [], "Execution Time": 20.658}]
+[
+  {
+    "Plan": {
+      "Node Type": "Seq Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Relation Name": "supplier",
+      "Schema": "pg_temp",
+      "Alias": "supplier",
+      "Startup Cost": 0.0,
+      "Total Cost": 1894.0,
+      "Plan Rows": 150,
+      "Plan Width": 511,
+      "Actual Startup Time": 0.085,
+      "Actual Total Time": 24.757,
+      "Actual Rows": 518,
+      "Actual Loops": 1,
+      "Output": [
+        "supplier.s_suppkey",
+        "supplier.s_name",
+        "supplier.s_address",
+        "supplier.s_nationkey",
+        "supplier.s_phone",
+        "supplier.s_acctbal",
+        "supplier.s_comment",
+        "EXISTS(SubPlan 1)"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "SubPlan",
+          "Subplan Name": "SubPlan 1",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Relation Name": "partsupp",
+          "Schema": "pg_temp",
+          "Alias": "partsupp",
+          "Startup Cost": 0.0,
+          "Total Cost": 12.55,
+          "Plan Rows": 1,
+          "Plan Width": 0,
+          "Actual Startup Time": 0.047,
+          "Actual Total Time": 0.047,
+          "Actual Rows": 0,
+          "Actual Loops": 518,
+          "Filter": "((supplier.s_acctbal < partsupp.ps_supplycost) AND (partsupp.ps_suppkey = supplier.s_suppkey))",
+          "Rows Removed by Filter": 494
+        }
+      ]
+    },
+    "Planning Time": 0.092,
+    "Triggers": [],
+    "Execution Time": 24.785
+  }
+]

--- a/standalone-app/examples/postgres/metadata-describe-table.plan.json
+++ b/standalone-app/examples/postgres/metadata-describe-table.plan.json
@@ -1,1 +1,30 @@
-[{"Plan": {"Node Type": "Index Scan", "Parallel Aware": false, "Async Capable": false, "Scan Direction": "Forward", "Index Name": "pg_class_oid_index", "Relation Name": "pg_class", "Schema": "pg_catalog", "Alias": "c", "Startup Cost": 0.27, "Total Cost": 8.3, "Plan Rows": 1, "Plan Width": 44, "Output": ["c.relchecks", "c.relkind", "c.relhasindex", "c.relhasrules", "c.relhastriggers", "false", "c.reltablespace", "CASE WHEN (c.reloftype = '0'::oid) THEN ''::text ELSE ((c.reloftype)::regtype)::text END", "c.relpersistence"], "Index Cond": "(c.oid = '12'::oid)"}}]
+[
+  {
+    "Plan": {
+      "Node Type": "Index Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Scan Direction": "Forward",
+      "Index Name": "pg_class_oid_index",
+      "Relation Name": "pg_class",
+      "Schema": "pg_catalog",
+      "Alias": "c",
+      "Startup Cost": 0.27,
+      "Total Cost": 8.3,
+      "Plan Rows": 1,
+      "Plan Width": 44,
+      "Output": [
+        "c.relchecks",
+        "c.relkind",
+        "c.relhasindex",
+        "c.relhasrules",
+        "c.relhastriggers",
+        "false",
+        "c.reltablespace",
+        "CASE WHEN (c.reloftype = '0'::oid) THEN ''::text ELSE ((c.reloftype)::regtype)::text END",
+        "c.relpersistence"
+      ],
+      "Index Cond": "(c.oid = '12'::oid)"
+    }
+  }
+]

--- a/standalone-app/examples/postgres/setoperation-analyze.plan.json
+++ b/standalone-app/examples/postgres/setoperation-analyze.plan.json
@@ -1,1 +1,321 @@
-[{"Plan": {"Node Type": "Append", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 69.86, "Plan Rows": 467, "Plan Width": 8, "Actual Startup Time": 0.005, "Actual Total Time": 0.253, "Actual Rows": 1144, "Actual Loops": 1, "Subplans Removed": 0, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 8, "Actual Startup Time": 0.005, "Actual Total Time": 0.021, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey"]}, {"Node Type": "Seq Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem_1", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.018, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem_1.l_orderkey", "lineitem_1.l_suppkey"]}, {"Node Type": "Result", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 43.53, "Plan Rows": 67, "Plan Width": 8, "Actual Startup Time": 0.181, "Actual Total Time": 0.182, "Actual Rows": 0, "Actual Loops": 1, "Output": ["\"*SELECT* 3\".l_suppkey", "\"*SELECT* 3\".l_partkey"], "Plans": [{"Node Type": "SetOp", "Strategy": "Hashed", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Command": "Except All", "Startup Cost": 0.0, "Total Cost": 42.86, "Plan Rows": 67, "Plan Width": 12, "Actual Startup Time": 0.181, "Actual Total Time": 0.182, "Actual Rows": 0, "Actual Loops": 1, "Output": ["\"*SELECT* 3\".l_suppkey", "\"*SELECT* 3\".l_partkey", "(0)"], "Plans": [{"Node Type": "Append", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 42.19, "Plan Rows": 134, "Plan Width": 12, "Actual Startup Time": 0.127, "Actual Total Time": 0.174, "Actual Rows": 302, "Actual Loops": 1, "Subplans Removed": 0, "Plans": [{"Node Type": "Result", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 28.35, "Plan Rows": 67, "Plan Width": 12, "Actual Startup Time": 0.127, "Actual Total Time": 0.129, "Actual Rows": 16, "Actual Loops": 1, "Output": ["\"*SELECT* 3\".l_suppkey", "\"*SELECT* 3\".l_partkey", "0"], "Plans": [{"Node Type": "SetOp", "Strategy": "Hashed", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Command": "Intersect All", "Startup Cost": 0.0, "Total Cost": 27.68, "Plan Rows": 67, "Plan Width": 12, "Actual Startup Time": 0.127, "Actual Total Time": 0.128, "Actual Rows": 16, "Actual Loops": 1, "Output": ["\"*SELECT* 3\".l_suppkey", "\"*SELECT* 3\".l_partkey", "(0)"], "Plans": [{"Node Type": "Append", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 27.01, "Plan Rows": 134, "Plan Width": 12, "Actual Startup Time": 0.002, "Actual Total Time": 0.09, "Actual Rows": 572, "Actual Loops": 1, "Subplans Removed": 0, "Plans": [{"Node Type": "Subquery Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Alias": "*SELECT* 3", "Startup Cost": 0.0, "Total Cost": 13.17, "Plan Rows": 67, "Plan Width": 12, "Actual Startup Time": 0.002, "Actual Total Time": 0.036, "Actual Rows": 286, "Actual Loops": 1, "Output": ["\"*SELECT* 3\".l_suppkey", "\"*SELECT* 3\".l_partkey", "0"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Subquery", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem_2", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.027, "Actual Rows": 286, "Actual Loops": 1, "Output": ["lineitem_2.l_suppkey", "lineitem_2.l_partkey"], "Filter": "(lineitem_2.l_quantity < '25'::numeric)", "Rows Removed by Filter": 286}]}, {"Node Type": "Subquery Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Alias": "*SELECT* 4", "Startup Cost": 0.0, "Total Cost": 13.17, "Plan Rows": 67, "Plan Width": 12, "Actual Startup Time": 0.002, "Actual Total Time": 0.037, "Actual Rows": 286, "Actual Loops": 1, "Output": ["\"*SELECT* 4\".l_suppkey", "\"*SELECT* 4\".l_partkey", "1"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Subquery", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem_3", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.028, "Actual Rows": 286, "Actual Loops": 1, "Output": ["lineitem_3.l_suppkey", "lineitem_3.l_partkey"], "Filter": "(lineitem_3.l_quantity >= '25'::numeric)", "Rows Removed by Filter": 286}]}]}]}]}, {"Node Type": "Subquery Scan", "Parent Relationship": "Member", "Parallel Aware": false, "Async Capable": false, "Alias": "*SELECT* 5", "Startup Cost": 0.0, "Total Cost": 13.17, "Plan Rows": 67, "Plan Width": 12, "Actual Startup Time": 0.001, "Actual Total Time": 0.036, "Actual Rows": 286, "Actual Loops": 1, "Output": ["\"*SELECT* 5\".l_suppkey", "\"*SELECT* 5\".l_partkey", "1"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Subquery", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem_4", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.027, "Actual Rows": 286, "Actual Loops": 1, "Output": ["lineitem_4.l_suppkey", "lineitem_4.l_partkey"], "Filter": "(lineitem_4.l_quantity >= '25'::numeric)", "Rows Removed by Filter": 286}]}]}]}]}]}, "Planning Time": 0.038, "Triggers": [], "Execution Time": 0.304}]
+[
+  {
+    "Plan": {
+      "Node Type": "Append",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 0.0,
+      "Total Cost": 69.86,
+      "Plan Rows": 467,
+      "Plan Width": 8,
+      "Actual Startup Time": 0.004,
+      "Actual Total Time": 0.476,
+      "Actual Rows": 1144,
+      "Actual Loops": 1,
+      "Subplans Removed": 0,
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Member",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Relation Name": "lineitem",
+          "Schema": "pg_temp",
+          "Alias": "lineitem",
+          "Startup Cost": 0.0,
+          "Total Cost": 12.0,
+          "Plan Rows": 200,
+          "Plan Width": 8,
+          "Actual Startup Time": 0.004,
+          "Actual Total Time": 0.033,
+          "Actual Rows": 572,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_orderkey",
+            "lineitem.l_partkey"
+          ]
+        },
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Member",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Relation Name": "lineitem",
+          "Schema": "pg_temp",
+          "Alias": "lineitem_1",
+          "Startup Cost": 0.0,
+          "Total Cost": 12.0,
+          "Plan Rows": 200,
+          "Plan Width": 8,
+          "Actual Startup Time": 0.002,
+          "Actual Total Time": 0.035,
+          "Actual Rows": 572,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem_1.l_orderkey",
+            "lineitem_1.l_suppkey"
+          ]
+        },
+        {
+          "Node Type": "Result",
+          "Parent Relationship": "Member",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 0.0,
+          "Total Cost": 43.53,
+          "Plan Rows": 67,
+          "Plan Width": 8,
+          "Actual Startup Time": 0.342,
+          "Actual Total Time": 0.343,
+          "Actual Rows": 0,
+          "Actual Loops": 1,
+          "Output": [
+            "\"*SELECT* 3\".l_suppkey",
+            "\"*SELECT* 3\".l_partkey"
+          ],
+          "Plans": [
+            {
+              "Node Type": "SetOp",
+              "Strategy": "Hashed",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Command": "Except All",
+              "Startup Cost": 0.0,
+              "Total Cost": 42.86,
+              "Plan Rows": 67,
+              "Plan Width": 12,
+              "Actual Startup Time": 0.342,
+              "Actual Total Time": 0.342,
+              "Actual Rows": 0,
+              "Actual Loops": 1,
+              "Output": [
+                "\"*SELECT* 3\".l_suppkey",
+                "\"*SELECT* 3\".l_partkey",
+                "(0)"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Append",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 0.0,
+                  "Total Cost": 42.19,
+                  "Plan Rows": 134,
+                  "Plan Width": 12,
+                  "Actual Startup Time": 0.235,
+                  "Actual Total Time": 0.328,
+                  "Actual Rows": 302,
+                  "Actual Loops": 1,
+                  "Subplans Removed": 0,
+                  "Plans": [
+                    {
+                      "Node Type": "Result",
+                      "Parent Relationship": "Member",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Startup Cost": 0.0,
+                      "Total Cost": 28.35,
+                      "Plan Rows": 67,
+                      "Plan Width": 12,
+                      "Actual Startup Time": 0.235,
+                      "Actual Total Time": 0.238,
+                      "Actual Rows": 16,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "\"*SELECT* 3\".l_suppkey",
+                        "\"*SELECT* 3\".l_partkey",
+                        "0"
+                      ],
+                      "Plans": [
+                        {
+                          "Node Type": "SetOp",
+                          "Strategy": "Hashed",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Command": "Intersect All",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 27.68,
+                          "Plan Rows": 67,
+                          "Plan Width": 12,
+                          "Actual Startup Time": 0.234,
+                          "Actual Total Time": 0.236,
+                          "Actual Rows": 16,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "\"*SELECT* 3\".l_suppkey",
+                            "\"*SELECT* 3\".l_partkey",
+                            "(0)"
+                          ],
+                          "Plans": [
+                            {
+                              "Node Type": "Append",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 0.0,
+                              "Total Cost": 27.01,
+                              "Plan Rows": 134,
+                              "Plan Width": 12,
+                              "Actual Startup Time": 0.003,
+                              "Actual Total Time": 0.176,
+                              "Actual Rows": 572,
+                              "Actual Loops": 1,
+                              "Subplans Removed": 0,
+                              "Plans": [
+                                {
+                                  "Node Type": "Subquery Scan",
+                                  "Parent Relationship": "Member",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Alias": "*SELECT* 3",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 13.17,
+                                  "Plan Rows": 67,
+                                  "Plan Width": 12,
+                                  "Actual Startup Time": 0.003,
+                                  "Actual Total Time": 0.073,
+                                  "Actual Rows": 286,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "\"*SELECT* 3\".l_suppkey",
+                                    "\"*SELECT* 3\".l_partkey",
+                                    "0"
+                                  ],
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Subquery",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "lineitem",
+                                      "Schema": "pg_temp",
+                                      "Alias": "lineitem_2",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 12.5,
+                                      "Plan Rows": 67,
+                                      "Plan Width": 8,
+                                      "Actual Startup Time": 0.003,
+                                      "Actual Total Time": 0.053,
+                                      "Actual Rows": 286,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "lineitem_2.l_suppkey",
+                                        "lineitem_2.l_partkey"
+                                      ],
+                                      "Filter": "(lineitem_2.l_quantity < '25'::numeric)",
+                                      "Rows Removed by Filter": 286
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Subquery Scan",
+                                  "Parent Relationship": "Member",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Alias": "*SELECT* 4",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 13.17,
+                                  "Plan Rows": 67,
+                                  "Plan Width": 12,
+                                  "Actual Startup Time": 0.003,
+                                  "Actual Total Time": 0.07,
+                                  "Actual Rows": 286,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "\"*SELECT* 4\".l_suppkey",
+                                    "\"*SELECT* 4\".l_partkey",
+                                    "1"
+                                  ],
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Subquery",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "lineitem",
+                                      "Schema": "pg_temp",
+                                      "Alias": "lineitem_3",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 12.5,
+                                      "Plan Rows": 67,
+                                      "Plan Width": 8,
+                                      "Actual Startup Time": 0.003,
+                                      "Actual Total Time": 0.051,
+                                      "Actual Rows": 286,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "lineitem_3.l_suppkey",
+                                        "lineitem_3.l_partkey"
+                                      ],
+                                      "Filter": "(lineitem_3.l_quantity >= '25'::numeric)",
+                                      "Rows Removed by Filter": 286
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Node Type": "Subquery Scan",
+                      "Parent Relationship": "Member",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Alias": "*SELECT* 5",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 13.17,
+                      "Plan Rows": 67,
+                      "Plan Width": 12,
+                      "Actual Startup Time": 0.002,
+                      "Actual Total Time": 0.072,
+                      "Actual Rows": 286,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "\"*SELECT* 5\".l_suppkey",
+                        "\"*SELECT* 5\".l_partkey",
+                        "1"
+                      ],
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Subquery",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "lineitem",
+                          "Schema": "pg_temp",
+                          "Alias": "lineitem_4",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.5,
+                          "Plan Rows": 67,
+                          "Plan Width": 8,
+                          "Actual Startup Time": 0.002,
+                          "Actual Total Time": 0.053,
+                          "Actual Rows": 286,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "lineitem_4.l_suppkey",
+                            "lineitem_4.l_partkey"
+                          ],
+                          "Filter": "(lineitem_4.l_quantity >= '25'::numeric)",
+                          "Rows Removed by Filter": 286
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.059,
+    "Triggers": [],
+    "Execution Time": 0.534
+  }
+]

--- a/standalone-app/examples/postgres/tableconstruction.plan.json
+++ b/standalone-app/examples/postgres/tableconstruction.plan.json
@@ -1,1 +1,18 @@
-[{"Plan": {"Node Type": "Values Scan", "Parallel Aware": false, "Async Capable": false, "Alias": "*VALUES*", "Startup Cost": 0.0, "Total Cost": 0.03, "Plan Rows": 2, "Plan Width": 64, "Output": ["column1", "column2"]}}]
+[
+  {
+    "Plan": {
+      "Node Type": "Values Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Alias": "*VALUES*",
+      "Startup Cost": 0.0,
+      "Total Cost": 0.03,
+      "Plan Rows": 2,
+      "Plan Width": 64,
+      "Output": [
+        "column1",
+        "column2"
+      ]
+    }
+  }
+]

--- a/standalone-app/examples/postgres/tablefunction.plan.json
+++ b/standalone-app/examples/postgres/tablefunction.plan.json
@@ -1,1 +1,20 @@
-[{"Plan": {"Node Type": "Function Scan", "Parallel Aware": false, "Async Capable": false, "Function Name": "generate_series", "Schema": "pg_catalog", "Alias": "generate_series", "Startup Cost": 0.0, "Total Cost": 0.1, "Plan Rows": 10, "Plan Width": 4, "Output": ["generate_series"], "Function Call": "generate_series(1, 10)"}}]
+[
+  {
+    "Plan": {
+      "Node Type": "Function Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Function Name": "generate_series",
+      "Schema": "pg_catalog",
+      "Alias": "generate_series",
+      "Startup Cost": 0.0,
+      "Total Cost": 0.1,
+      "Plan Rows": 10,
+      "Plan Width": 4,
+      "Output": [
+        "generate_series"
+      ],
+      "Function Call": "generate_series(1, 10)"
+    }
+  }
+]

--- a/standalone-app/examples/postgres/tablescan-analyze.plan.json
+++ b/standalone-app/examples/postgres/tablescan-analyze.plan.json
@@ -1,1 +1,26 @@
-[{"Plan": {"Node Type": "Seq Scan", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 104, "Actual Startup Time": 0.004, "Actual Total Time": 0.004, "Actual Rows": 5, "Actual Loops": 1, "Output": ["r_name"]}, "Planning Time": 0.014, "Triggers": [], "Execution Time": 0.006}]
+[
+  {
+    "Plan": {
+      "Node Type": "Seq Scan",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Relation Name": "region",
+      "Schema": "pg_temp",
+      "Alias": "region",
+      "Startup Cost": 0.0,
+      "Total Cost": 11.7,
+      "Plan Rows": 170,
+      "Plan Width": 104,
+      "Actual Startup Time": 0.003,
+      "Actual Total Time": 0.003,
+      "Actual Rows": 5,
+      "Actual Loops": 1,
+      "Output": [
+        "r_name"
+      ]
+    },
+    "Planning Time": 0.016,
+    "Triggers": [],
+    "Execution Time": 0.006
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q1-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q1-analyze.plan.json
@@ -1,1 +1,98 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 14.53, "Total Cost": 18.89, "Plan Rows": 67, "Plan Width": 248, "Actual Startup Time": 0.325, "Actual Total Time": 0.646, "Actual Rows": 4, "Actual Loops": 1, "Output": ["l_returnflag", "l_linestatus", "sum(l_quantity)", "sum(l_extendedprice)", "sum((l_extendedprice * ('1'::numeric - l_discount)))", "sum(((l_extendedprice * ('1'::numeric - l_discount)) * ('1'::numeric + l_tax)))", "avg(l_quantity)", "avg(l_extendedprice)", "avg(l_discount)", "count(*)"], "Group Key": ["lineitem.l_returnflag", "lineitem.l_linestatus"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 14.53, "Total Cost": 14.7, "Plan Rows": 67, "Plan Width": 80, "Actual Startup Time": 0.187, "Actual Total Time": 0.215, "Actual Rows": 568, "Actual Loops": 1, "Output": ["l_returnflag", "l_linestatus", "l_quantity", "l_extendedprice", "l_discount", "l_tax"], "Sort Key": ["lineitem.l_returnflag", "lineitem.l_linestatus"], "Sort Method": "quicksort", "Sort Space Used": 64, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 80, "Actual Startup Time": 0.005, "Actual Total Time": 0.073, "Actual Rows": 568, "Actual Loops": 1, "Output": ["l_returnflag", "l_linestatus", "l_quantity", "l_extendedprice", "l_discount", "l_tax"], "Filter": "(lineitem.l_shipdate <= '1998-09-02 00:00:00'::timestamp without time zone)", "Rows Removed by Filter": 4}]}]}, "Planning Time": 0.061, "Triggers": [], "Execution Time": 0.663}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 14.53,
+      "Total Cost": 18.89,
+      "Plan Rows": 67,
+      "Plan Width": 248,
+      "Actual Startup Time": 0.313,
+      "Actual Total Time": 0.544,
+      "Actual Rows": 4,
+      "Actual Loops": 1,
+      "Output": [
+        "l_returnflag",
+        "l_linestatus",
+        "sum(l_quantity)",
+        "sum(l_extendedprice)",
+        "sum((l_extendedprice * ('1'::numeric - l_discount)))",
+        "sum(((l_extendedprice * ('1'::numeric - l_discount)) * ('1'::numeric + l_tax)))",
+        "avg(l_quantity)",
+        "avg(l_extendedprice)",
+        "avg(l_discount)",
+        "count(*)"
+      ],
+      "Group Key": [
+        "lineitem.l_returnflag",
+        "lineitem.l_linestatus"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 14.53,
+          "Total Cost": 14.7,
+          "Plan Rows": 67,
+          "Plan Width": 80,
+          "Actual Startup Time": 0.21,
+          "Actual Total Time": 0.228,
+          "Actual Rows": 568,
+          "Actual Loops": 1,
+          "Output": [
+            "l_returnflag",
+            "l_linestatus",
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax"
+          ],
+          "Sort Key": [
+            "lineitem.l_returnflag",
+            "lineitem.l_linestatus"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 51,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "lineitem",
+              "Schema": "pg_temp",
+              "Alias": "lineitem",
+              "Startup Cost": 0.0,
+              "Total Cost": 12.5,
+              "Plan Rows": 67,
+              "Plan Width": 80,
+              "Actual Startup Time": 0.004,
+              "Actual Total Time": 0.061,
+              "Actual Rows": 568,
+              "Actual Loops": 1,
+              "Output": [
+                "l_returnflag",
+                "l_linestatus",
+                "l_quantity",
+                "l_extendedprice",
+                "l_discount",
+                "l_tax"
+              ],
+              "Filter": "(lineitem.l_shipdate <= '1998-09-02 00:00:00'::timestamp without time zone)",
+              "Rows Removed by Filter": 4
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.074,
+    "Triggers": [],
+    "Execution Time": 0.557
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q10-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q10-analyze.plan.json
@@ -1,1 +1,395 @@
-[{"Plan": {"Node Type": "Limit", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 50.03, "Total Cost": 50.04, "Plan Rows": 1, "Plan Width": 638, "Actual Startup Time": 0.611, "Actual Total Time": 0.613, "Actual Rows": 8, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))", "customer.c_acctbal", "nation.n_name", "customer.c_address", "customer.c_phone", "customer.c_comment"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 50.03, "Total Cost": 50.04, "Plan Rows": 1, "Plan Width": 638, "Actual Startup Time": 0.61, "Actual Total Time": 0.612, "Actual Rows": 8, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))", "customer.c_acctbal", "nation.n_name", "customer.c_address", "customer.c_phone", "customer.c_comment"], "Sort Key": ["(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))) DESC"], "Sort Method": "quicksort", "Sort Space Used": 26, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 49.98, "Total Cost": 50.02, "Plan Rows": 1, "Plan Width": 638, "Actual Startup Time": 0.591, "Actual Total Time": 0.607, "Actual Rows": 8, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))", "customer.c_acctbal", "nation.n_name", "customer.c_address", "customer.c_phone", "customer.c_comment"], "Group Key": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "customer.c_phone", "nation.n_name", "customer.c_address", "customer.c_comment"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 49.98, "Total Cost": 49.98, "Plan Rows": 1, "Plan Width": 638, "Actual Startup Time": 0.586, "Actual Total Time": 0.588, "Actual Rows": 23, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "nation.n_name", "customer.c_address", "customer.c_phone", "customer.c_comment", "lineitem.l_extendedprice", "lineitem.l_discount"], "Sort Key": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "customer.c_phone", "nation.n_name", "customer.c_address", "customer.c_comment"], "Sort Method": "quicksort", "Sort Space Used": 28, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 25.11, "Total Cost": 49.97, "Plan Rows": 1, "Plan Width": 638, "Actual Startup Time": 0.041, "Actual Total Time": 0.57, "Actual Rows": 23, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "nation.n_name", "customer.c_address", "customer.c_phone", "customer.c_comment", "lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Join Filter": "(orders.o_orderkey = lineitem.l_orderkey)", "Rows Removed by Join Filter": 1345, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 25.11, "Total Cost": 37.46, "Plan Rows": 1, "Plan Width": 610, "Actual Startup Time": 0.038, "Actual Total Time": 0.043, "Actual Rows": 9, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "customer.c_address", "customer.c_phone", "customer.c_comment", "orders.o_orderkey", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(nation.n_nationkey = customer.c_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 108, "Actual Startup Time": 0.002, "Actual Total Time": 0.003, "Actual Rows": 25, "Actual Loops": 1, "Output": ["nation.n_nationkey", "nation.n_name", "nation.n_regionkey", "nation.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 25.1, "Total Cost": 25.1, "Plan Rows": 1, "Plan Width": 510, "Actual Startup Time": 0.034, "Actual Total Time": 0.034, "Actual Rows": 9, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "customer.c_address", "customer.c_phone", "customer.c_comment", "customer.c_nationkey", "orders.o_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 10, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 13.16, "Total Cost": 25.1, "Plan Rows": 1, "Plan Width": 510, "Actual Startup Time": 0.017, "Actual Total Time": 0.032, "Actual Rows": 9, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_acctbal", "customer.c_address", "customer.c_phone", "customer.c_comment", "customer.c_nationkey", "orders.o_orderkey"], "Inner Unique": false, "Hash Cond": "(customer.c_custkey = orders.o_custkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 506, "Actual Startup Time": 0.001, "Actual Total Time": 0.007, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_address", "customer.c_nationkey", "customer.c_phone", "customer.c_acctbal", "customer.c_mktsegment", "customer.c_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.15, "Total Cost": 13.15, "Plan Rows": 1, "Plan Width": 8, "Actual Startup Time": 0.013, "Actual Total Time": 0.013, "Actual Rows": 9, "Actual Loops": 1, "Output": ["orders.o_custkey", "orders.o_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 13.15, "Plan Rows": 1, "Plan Width": 8, "Actual Startup Time": 0.003, "Actual Total Time": 0.011, "Actual Rows": 9, "Actual Loops": 1, "Output": ["orders.o_custkey", "orders.o_orderkey"], "Filter": "((orders.o_orderdate >= '1993-10-01'::date) AND (orders.o_orderdate < '1994-01-01'::date))", "Rows Removed by Filter": 119}]}]}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.001, "Actual Total Time": 0.053, "Actual Rows": 152, "Actual Loops": 9, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "(lineitem.l_returnflag = 'R'::bpchar)", "Rows Removed by Filter": 420}]}]}]}]}]}, "Planning Time": 0.104, "Triggers": [], "Execution Time": 0.634}]
+[
+  {
+    "Plan": {
+      "Node Type": "Limit",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 50.03,
+      "Total Cost": 50.04,
+      "Plan Rows": 1,
+      "Plan Width": 638,
+      "Actual Startup Time": 0.552,
+      "Actual Total Time": 0.554,
+      "Actual Rows": 8,
+      "Actual Loops": 1,
+      "Output": [
+        "customer.c_custkey",
+        "customer.c_name",
+        "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))",
+        "customer.c_acctbal",
+        "nation.n_name",
+        "customer.c_address",
+        "customer.c_phone",
+        "customer.c_comment"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 50.03,
+          "Total Cost": 50.04,
+          "Plan Rows": 1,
+          "Plan Width": 638,
+          "Actual Startup Time": 0.552,
+          "Actual Total Time": 0.553,
+          "Actual Rows": 8,
+          "Actual Loops": 1,
+          "Output": [
+            "customer.c_custkey",
+            "customer.c_name",
+            "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))",
+            "customer.c_acctbal",
+            "nation.n_name",
+            "customer.c_address",
+            "customer.c_phone",
+            "customer.c_comment"
+          ],
+          "Sort Key": [
+            "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))) DESC"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 26,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Aggregate",
+              "Strategy": "Sorted",
+              "Partial Mode": "Simple",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 49.98,
+              "Total Cost": 50.02,
+              "Plan Rows": 1,
+              "Plan Width": 638,
+              "Actual Startup Time": 0.533,
+              "Actual Total Time": 0.547,
+              "Actual Rows": 8,
+              "Actual Loops": 1,
+              "Output": [
+                "customer.c_custkey",
+                "customer.c_name",
+                "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))",
+                "customer.c_acctbal",
+                "nation.n_name",
+                "customer.c_address",
+                "customer.c_phone",
+                "customer.c_comment"
+              ],
+              "Group Key": [
+                "customer.c_custkey",
+                "customer.c_name",
+                "customer.c_acctbal",
+                "customer.c_phone",
+                "nation.n_name",
+                "customer.c_address",
+                "customer.c_comment"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Sort",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 49.98,
+                  "Total Cost": 49.98,
+                  "Plan Rows": 1,
+                  "Plan Width": 638,
+                  "Actual Startup Time": 0.529,
+                  "Actual Total Time": 0.531,
+                  "Actual Rows": 23,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "customer.c_custkey",
+                    "customer.c_name",
+                    "customer.c_acctbal",
+                    "nation.n_name",
+                    "customer.c_address",
+                    "customer.c_phone",
+                    "customer.c_comment",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount"
+                  ],
+                  "Sort Key": [
+                    "customer.c_custkey",
+                    "customer.c_name",
+                    "customer.c_acctbal",
+                    "customer.c_phone",
+                    "nation.n_name",
+                    "customer.c_address",
+                    "customer.c_comment"
+                  ],
+                  "Sort Method": "quicksort",
+                  "Sort Space Used": 28,
+                  "Sort Space Type": "Memory",
+                  "Plans": [
+                    {
+                      "Node Type": "Nested Loop",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 25.11,
+                      "Total Cost": 49.97,
+                      "Plan Rows": 1,
+                      "Plan Width": 638,
+                      "Actual Startup Time": 0.05,
+                      "Actual Total Time": 0.508,
+                      "Actual Rows": 23,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "customer.c_custkey",
+                        "customer.c_name",
+                        "customer.c_acctbal",
+                        "nation.n_name",
+                        "customer.c_address",
+                        "customer.c_phone",
+                        "customer.c_comment",
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount"
+                      ],
+                      "Inner Unique": false,
+                      "Join Filter": "(orders.o_orderkey = lineitem.l_orderkey)",
+                      "Rows Removed by Join Filter": 1345,
+                      "Plans": [
+                        {
+                          "Node Type": "Hash Join",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Join Type": "Inner",
+                          "Startup Cost": 25.11,
+                          "Total Cost": 37.46,
+                          "Plan Rows": 1,
+                          "Plan Width": 610,
+                          "Actual Startup Time": 0.045,
+                          "Actual Total Time": 0.051,
+                          "Actual Rows": 9,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "customer.c_custkey",
+                            "customer.c_name",
+                            "customer.c_acctbal",
+                            "customer.c_address",
+                            "customer.c_phone",
+                            "customer.c_comment",
+                            "orders.o_orderkey",
+                            "nation.n_name"
+                          ],
+                          "Inner Unique": false,
+                          "Hash Cond": "(nation.n_nationkey = customer.c_nationkey)",
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "nation",
+                              "Schema": "pg_temp",
+                              "Alias": "nation",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 11.7,
+                              "Plan Rows": 170,
+                              "Plan Width": 108,
+                              "Actual Startup Time": 0.002,
+                              "Actual Total Time": 0.003,
+                              "Actual Rows": 25,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "nation.n_nationkey",
+                                "nation.n_name",
+                                "nation.n_regionkey",
+                                "nation.n_comment"
+                              ]
+                            },
+                            {
+                              "Node Type": "Hash",
+                              "Parent Relationship": "Inner",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 25.1,
+                              "Total Cost": 25.1,
+                              "Plan Rows": 1,
+                              "Plan Width": 510,
+                              "Actual Startup Time": 0.034,
+                              "Actual Total Time": 0.034,
+                              "Actual Rows": 9,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "customer.c_custkey",
+                                "customer.c_name",
+                                "customer.c_acctbal",
+                                "customer.c_address",
+                                "customer.c_phone",
+                                "customer.c_comment",
+                                "customer.c_nationkey",
+                                "orders.o_orderkey"
+                              ],
+                              "Hash Buckets": 1024,
+                              "Original Hash Buckets": 1024,
+                              "Hash Batches": 1,
+                              "Original Hash Batches": 1,
+                              "Peak Memory Usage": 10,
+                              "Plans": [
+                                {
+                                  "Node Type": "Hash Join",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Join Type": "Inner",
+                                  "Startup Cost": 13.16,
+                                  "Total Cost": 25.1,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 510,
+                                  "Actual Startup Time": 0.019,
+                                  "Actual Total Time": 0.03,
+                                  "Actual Rows": 9,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "customer.c_custkey",
+                                    "customer.c_name",
+                                    "customer.c_acctbal",
+                                    "customer.c_address",
+                                    "customer.c_phone",
+                                    "customer.c_comment",
+                                    "customer.c_nationkey",
+                                    "orders.o_orderkey"
+                                  ],
+                                  "Inner Unique": false,
+                                  "Hash Cond": "(customer.c_custkey = orders.o_custkey)",
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "customer",
+                                      "Schema": "pg_temp",
+                                      "Alias": "customer",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 11.4,
+                                      "Plan Rows": 140,
+                                      "Plan Width": 506,
+                                      "Actual Startup Time": 0.002,
+                                      "Actual Total Time": 0.007,
+                                      "Actual Rows": 129,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "customer.c_custkey",
+                                        "customer.c_name",
+                                        "customer.c_address",
+                                        "customer.c_nationkey",
+                                        "customer.c_phone",
+                                        "customer.c_acctbal",
+                                        "customer.c_mktsegment",
+                                        "customer.c_comment"
+                                      ]
+                                    },
+                                    {
+                                      "Node Type": "Hash",
+                                      "Parent Relationship": "Inner",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Startup Cost": 13.15,
+                                      "Total Cost": 13.15,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 8,
+                                      "Actual Startup Time": 0.012,
+                                      "Actual Total Time": 0.012,
+                                      "Actual Rows": 9,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "orders.o_custkey",
+                                        "orders.o_orderkey"
+                                      ],
+                                      "Hash Buckets": 1024,
+                                      "Original Hash Buckets": 1024,
+                                      "Hash Batches": 1,
+                                      "Original Hash Batches": 1,
+                                      "Peak Memory Usage": 9,
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "orders",
+                                          "Schema": "pg_temp",
+                                          "Alias": "orders",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 13.15,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 8,
+                                          "Actual Startup Time": 0.003,
+                                          "Actual Total Time": 0.009,
+                                          "Actual Rows": 9,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "orders.o_custkey",
+                                            "orders.o_orderkey"
+                                          ],
+                                          "Filter": "((orders.o_orderdate >= '1993-10-01'::date) AND (orders.o_orderdate < '1994-01-01'::date))",
+                                          "Rows Removed by Filter": 119
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "lineitem",
+                          "Schema": "pg_temp",
+                          "Alias": "lineitem",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.5,
+                          "Plan Rows": 1,
+                          "Plan Width": 36,
+                          "Actual Startup Time": 0.001,
+                          "Actual Total Time": 0.045,
+                          "Actual Rows": 152,
+                          "Actual Loops": 9,
+                          "Output": [
+                            "lineitem.l_orderkey",
+                            "lineitem.l_partkey",
+                            "lineitem.l_suppkey",
+                            "lineitem.l_linenumber",
+                            "lineitem.l_quantity",
+                            "lineitem.l_extendedprice",
+                            "lineitem.l_discount",
+                            "lineitem.l_tax",
+                            "lineitem.l_returnflag",
+                            "lineitem.l_linestatus",
+                            "lineitem.l_shipdate",
+                            "lineitem.l_commitdate",
+                            "lineitem.l_receiptdate",
+                            "lineitem.l_shipinstruct",
+                            "lineitem.l_shipmode",
+                            "lineitem.l_comment"
+                          ],
+                          "Filter": "(lineitem.l_returnflag = 'R'::bpchar)",
+                          "Rows Removed by Filter": 420
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.13,
+    "Triggers": [],
+    "Execution Time": 0.579
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q11-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q11-analyze.plan.json
@@ -1,1 +1,439 @@
-[{"Plan": {"Node Type": "Sort", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 73.21, "Total Cost": 73.22, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.286, "Actual Total Time": 0.288, "Actual Rows": 21, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "(sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric)))"], "Sort Key": ["(sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric))) DESC"], "Sort Method": "quicksort", "Sort Space Used": 26, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "InitPlan", "Subplan Name": "InitPlan 1 (returns $0)", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 36.58, "Total Cost": 36.59, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.128, "Actual Total Time": 0.128, "Actual Rows": 1, "Actual Loops": 1, "Output": ["(sum((partsupp_1.ps_supplycost * (partsupp_1.ps_availqty)::numeric)) * 0.0001)"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.22, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 20, "Actual Startup Time": 0.067, "Actual Total Time": 0.122, "Actual Rows": 21, "Actual Loops": 1, "Output": ["partsupp_1.ps_supplycost", "partsupp_1.ps_availqty"], "Inner Unique": false, "Hash Cond": "(partsupp_1.ps_suppkey = supplier_1.s_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp_1", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 24, "Actual Startup Time": 0.002, "Actual Total Time": 0.026, "Actual Rows": 537, "Actual Loops": 1, "Output": ["partsupp_1.ps_partkey", "partsupp_1.ps_suppkey", "partsupp_1.ps_availqty", "partsupp_1.ps_supplycost", "partsupp_1.ps_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.21, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.063, "Actual Total Time": 0.064, "Actual Rows": 19, "Actual Loops": 1, "Output": ["supplier_1.s_suppkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.007, "Actual Total Time": 0.062, "Actual Rows": 19, "Actual Loops": 1, "Output": ["supplier_1.s_suppkey"], "Inner Unique": false, "Hash Cond": "(supplier_1.s_nationkey = nation_1.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier_1", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.025, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier_1.s_suppkey", "supplier_1.s_name", "supplier_1.s_address", "supplier_1.s_nationkey", "supplier_1.s_phone", "supplier_1.s_acctbal", "supplier_1.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.003, "Actual Total Time": 0.003, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation_1.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation_1", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.001, "Actual Total Time": 0.003, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation_1.n_nationkey"], "Filter": "(nation_1.n_name = 'GERMANY'::bpchar)", "Rows Removed by Filter": 24}]}]}]}]}]}, {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 36.58, "Total Cost": 36.61, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.267, "Actual Total Time": 0.281, "Actual Rows": 21, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric))"], "Group Key": ["partsupp.ps_partkey"], "Filter": "(sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric)) > $0)", "Rows Removed by Filter": 0, "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 36.58, "Total Cost": 36.59, "Plan Rows": 1, "Plan Width": 24, "Actual Startup Time": 0.134, "Actual Total Time": 0.136, "Actual Rows": 21, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_supplycost", "partsupp.ps_availqty"], "Sort Key": ["partsupp.ps_partkey"], "Sort Method": "quicksort", "Sort Space Used": 26, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.22, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 24, "Actual Startup Time": 0.075, "Actual Total Time": 0.13, "Actual Rows": 21, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_supplycost", "partsupp.ps_availqty"], "Inner Unique": false, "Hash Cond": "(partsupp.ps_suppkey = supplier.s_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 28, "Actual Startup Time": 0.004, "Actual Total Time": 0.027, "Actual Rows": 537, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_suppkey", "partsupp.ps_availqty", "partsupp.ps_supplycost", "partsupp.ps_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.21, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.069, "Actual Total Time": 0.069, "Actual Rows": 19, "Actual Loops": 1, "Output": ["supplier.s_suppkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.011, "Actual Total Time": 0.067, "Actual Rows": 19, "Actual Loops": 1, "Output": ["supplier.s_suppkey"], "Inner Unique": false, "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.027, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.005, "Actual Total Time": 0.005, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.003, "Actual Total Time": 0.004, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_nationkey"], "Filter": "(nation.n_name = 'GERMANY'::bpchar)", "Rows Removed by Filter": 24}]}]}]}]}]}]}]}, "Planning Time": 0.094, "Triggers": [], "Execution Time": 0.312}]
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 73.21,
+      "Total Cost": 73.22,
+      "Plan Rows": 1,
+      "Plan Width": 36,
+      "Actual Startup Time": 0.244,
+      "Actual Total Time": 0.246,
+      "Actual Rows": 21,
+      "Actual Loops": 1,
+      "Output": [
+        "partsupp.ps_partkey",
+        "(sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric)))"
+      ],
+      "Sort Key": [
+        "(sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric))) DESC"
+      ],
+      "Sort Method": "quicksort",
+      "Sort Space Used": 25,
+      "Sort Space Type": "Memory",
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Plain",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "InitPlan",
+          "Subplan Name": "InitPlan 1",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 36.58,
+          "Total Cost": 36.59,
+          "Plan Rows": 1,
+          "Plan Width": 32,
+          "Actual Startup Time": 0.114,
+          "Actual Total Time": 0.114,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "(sum((partsupp_1.ps_supplycost * (partsupp_1.ps_availqty)::numeric)) * 0.0001)"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 24.22,
+              "Total Cost": 36.57,
+              "Plan Rows": 1,
+              "Plan Width": 20,
+              "Actual Startup Time": 0.065,
+              "Actual Total Time": 0.109,
+              "Actual Rows": 21,
+              "Actual Loops": 1,
+              "Output": [
+                "partsupp_1.ps_supplycost",
+                "partsupp_1.ps_availqty"
+              ],
+              "Inner Unique": false,
+              "Hash Cond": "(partsupp_1.ps_suppkey = supplier_1.s_suppkey)",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "partsupp",
+                  "Schema": "pg_temp",
+                  "Alias": "partsupp_1",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 11.7,
+                  "Plan Rows": 170,
+                  "Plan Width": 24,
+                  "Actual Startup Time": 0.002,
+                  "Actual Total Time": 0.023,
+                  "Actual Rows": 537,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "partsupp_1.ps_partkey",
+                    "partsupp_1.ps_suppkey",
+                    "partsupp_1.ps_availqty",
+                    "partsupp_1.ps_supplycost",
+                    "partsupp_1.ps_comment"
+                  ]
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 24.21,
+                  "Total Cost": 24.21,
+                  "Plan Rows": 1,
+                  "Plan Width": 4,
+                  "Actual Startup Time": 0.058,
+                  "Actual Total Time": 0.059,
+                  "Actual Rows": 19,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "supplier_1.s_suppkey"
+                  ],
+                  "Hash Buckets": 1024,
+                  "Original Hash Buckets": 1024,
+                  "Hash Batches": 1,
+                  "Original Hash Batches": 1,
+                  "Peak Memory Usage": 9,
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 12.14,
+                      "Total Cost": 24.21,
+                      "Plan Rows": 1,
+                      "Plan Width": 4,
+                      "Actual Startup Time": 0.013,
+                      "Actual Total Time": 0.055,
+                      "Actual Rows": 19,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "supplier_1.s_suppkey"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(supplier_1.s_nationkey = nation_1.n_nationkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "supplier",
+                          "Schema": "pg_temp",
+                          "Alias": "supplier_1",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.5,
+                          "Plan Rows": 150,
+                          "Plan Width": 8,
+                          "Actual Startup Time": 0.001,
+                          "Actual Total Time": 0.021,
+                          "Actual Rows": 518,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "supplier_1.s_suppkey",
+                            "supplier_1.s_name",
+                            "supplier_1.s_address",
+                            "supplier_1.s_nationkey",
+                            "supplier_1.s_phone",
+                            "supplier_1.s_acctbal",
+                            "supplier_1.s_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 12.12,
+                          "Total Cost": 12.12,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.005,
+                          "Actual Total Time": 0.005,
+                          "Actual Rows": 1,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "nation_1.n_nationkey"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 9,
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "nation",
+                              "Schema": "pg_temp",
+                              "Alias": "nation_1",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 12.12,
+                              "Plan Rows": 1,
+                              "Plan Width": 4,
+                              "Actual Startup Time": 0.002,
+                              "Actual Total Time": 0.003,
+                              "Actual Rows": 1,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "nation_1.n_nationkey"
+                              ],
+                              "Filter": "(nation_1.n_name = 'GERMANY'::bpchar)",
+                              "Rows Removed by Filter": 24
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Sorted",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 36.58,
+          "Total Cost": 36.61,
+          "Plan Rows": 1,
+          "Plan Width": 36,
+          "Actual Startup Time": 0.231,
+          "Actual Total Time": 0.241,
+          "Actual Rows": 21,
+          "Actual Loops": 1,
+          "Output": [
+            "partsupp.ps_partkey",
+            "sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric))"
+          ],
+          "Group Key": [
+            "partsupp.ps_partkey"
+          ],
+          "Filter": "(sum((partsupp.ps_supplycost * (partsupp.ps_availqty)::numeric)) > (InitPlan 1).col1)",
+          "Rows Removed by Filter": 0,
+          "Plans": [
+            {
+              "Node Type": "Sort",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 36.58,
+              "Total Cost": 36.59,
+              "Plan Rows": 1,
+              "Plan Width": 24,
+              "Actual Startup Time": 0.113,
+              "Actual Total Time": 0.115,
+              "Actual Rows": 21,
+              "Actual Loops": 1,
+              "Output": [
+                "partsupp.ps_partkey",
+                "partsupp.ps_supplycost",
+                "partsupp.ps_availqty"
+              ],
+              "Sort Key": [
+                "partsupp.ps_partkey"
+              ],
+              "Sort Method": "quicksort",
+              "Sort Space Used": 25,
+              "Sort Space Type": "Memory",
+              "Plans": [
+                {
+                  "Node Type": "Hash Join",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 24.22,
+                  "Total Cost": 36.57,
+                  "Plan Rows": 1,
+                  "Plan Width": 24,
+                  "Actual Startup Time": 0.066,
+                  "Actual Total Time": 0.111,
+                  "Actual Rows": 21,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "partsupp.ps_partkey",
+                    "partsupp.ps_supplycost",
+                    "partsupp.ps_availqty"
+                  ],
+                  "Inner Unique": false,
+                  "Hash Cond": "(partsupp.ps_suppkey = supplier.s_suppkey)",
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "partsupp",
+                      "Schema": "pg_temp",
+                      "Alias": "partsupp",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 11.7,
+                      "Plan Rows": 170,
+                      "Plan Width": 28,
+                      "Actual Startup Time": 0.003,
+                      "Actual Total Time": 0.024,
+                      "Actual Rows": 537,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "partsupp.ps_partkey",
+                        "partsupp.ps_suppkey",
+                        "partsupp.ps_availqty",
+                        "partsupp.ps_supplycost",
+                        "partsupp.ps_comment"
+                      ]
+                    },
+                    {
+                      "Node Type": "Hash",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Startup Cost": 24.21,
+                      "Total Cost": 24.21,
+                      "Plan Rows": 1,
+                      "Plan Width": 4,
+                      "Actual Startup Time": 0.06,
+                      "Actual Total Time": 0.06,
+                      "Actual Rows": 19,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "supplier.s_suppkey"
+                      ],
+                      "Hash Buckets": 1024,
+                      "Original Hash Buckets": 1024,
+                      "Hash Batches": 1,
+                      "Original Hash Batches": 1,
+                      "Peak Memory Usage": 9,
+                      "Plans": [
+                        {
+                          "Node Type": "Hash Join",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Join Type": "Inner",
+                          "Startup Cost": 12.14,
+                          "Total Cost": 24.21,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.015,
+                          "Actual Total Time": 0.058,
+                          "Actual Rows": 19,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "supplier.s_suppkey"
+                          ],
+                          "Inner Unique": false,
+                          "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)",
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "supplier",
+                              "Schema": "pg_temp",
+                              "Alias": "supplier",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 11.5,
+                              "Plan Rows": 150,
+                              "Plan Width": 8,
+                              "Actual Startup Time": 0.002,
+                              "Actual Total Time": 0.022,
+                              "Actual Rows": 518,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "supplier.s_suppkey",
+                                "supplier.s_name",
+                                "supplier.s_address",
+                                "supplier.s_nationkey",
+                                "supplier.s_phone",
+                                "supplier.s_acctbal",
+                                "supplier.s_comment"
+                              ]
+                            },
+                            {
+                              "Node Type": "Hash",
+                              "Parent Relationship": "Inner",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 12.12,
+                              "Total Cost": 12.12,
+                              "Plan Rows": 1,
+                              "Plan Width": 4,
+                              "Actual Startup Time": 0.006,
+                              "Actual Total Time": 0.006,
+                              "Actual Rows": 1,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "nation.n_nationkey"
+                              ],
+                              "Hash Buckets": 1024,
+                              "Original Hash Buckets": 1024,
+                              "Hash Batches": 1,
+                              "Original Hash Batches": 1,
+                              "Peak Memory Usage": 9,
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "nation",
+                                  "Schema": "pg_temp",
+                                  "Alias": "nation",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 12.12,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 4,
+                                  "Actual Startup Time": 0.002,
+                                  "Actual Total Time": 0.004,
+                                  "Actual Rows": 1,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "nation.n_nationkey"
+                                  ],
+                                  "Filter": "(nation.n_name = 'GERMANY'::bpchar)",
+                                  "Rows Removed by Filter": 24
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.075,
+    "Triggers": [],
+    "Execution Time": 0.263
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q12-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q12-analyze.plan.json
@@ -1,1 +1,157 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 27.42, "Total Cost": 27.45, "Plan Rows": 1, "Plan Width": 60, "Actual Startup Time": 0.116, "Actual Total Time": 0.117, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem.l_shipmode", "sum(CASE WHEN ((orders.o_orderpriority = '1-URGENT'::bpchar) OR (orders.o_orderpriority = '2-HIGH'::bpchar)) THEN 1 ELSE 0 END)", "sum(CASE WHEN ((orders.o_orderpriority <> '1-URGENT'::bpchar) AND (orders.o_orderpriority <> '2-HIGH'::bpchar)) THEN 1 ELSE 0 END)"], "Group Key": ["lineitem.l_shipmode"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 27.42, "Total Cost": 27.42, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.112, "Actual Total Time": 0.113, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem.l_shipmode", "orders.o_orderpriority"], "Sort Key": ["lineitem.l_shipmode"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 14.51, "Total Cost": 27.41, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.101, "Actual Total Time": 0.109, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem.l_shipmode", "orders.o_orderpriority"], "Inner Unique": false, "Hash Cond": "(orders.o_orderkey = lineitem.l_orderkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.1, "Plan Rows": 210, "Plan Width": 68, "Actual Startup Time": 0.004, "Actual Total Time": 0.009, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 14.5, "Total Cost": 14.5, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.089, "Actual Total Time": 0.089, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem.l_shipmode", "lineitem.l_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 14.5, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.04, "Actual Total Time": 0.087, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem.l_shipmode", "lineitem.l_orderkey"], "Filter": "((lineitem.l_shipmode = ANY ('{MAIL,SHIP}'::bpchar[])) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01'::date) AND (lineitem.l_receiptdate < '1995-01-01'::date))", "Rows Removed by Filter": 570}]}]}]}]}, "Planning Time": 0.061, "Triggers": [], "Execution Time": 0.134}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 27.42,
+      "Total Cost": 27.45,
+      "Plan Rows": 1,
+      "Plan Width": 60,
+      "Actual Startup Time": 0.109,
+      "Actual Total Time": 0.11,
+      "Actual Rows": 2,
+      "Actual Loops": 1,
+      "Output": [
+        "lineitem.l_shipmode",
+        "sum(CASE WHEN ((orders.o_orderpriority = '1-URGENT'::bpchar) OR (orders.o_orderpriority = '2-HIGH'::bpchar)) THEN 1 ELSE 0 END)",
+        "sum(CASE WHEN ((orders.o_orderpriority <> '1-URGENT'::bpchar) AND (orders.o_orderpriority <> '2-HIGH'::bpchar)) THEN 1 ELSE 0 END)"
+      ],
+      "Group Key": [
+        "lineitem.l_shipmode"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 27.42,
+          "Total Cost": 27.42,
+          "Plan Rows": 1,
+          "Plan Width": 108,
+          "Actual Startup Time": 0.105,
+          "Actual Total Time": 0.106,
+          "Actual Rows": 2,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_shipmode",
+            "orders.o_orderpriority"
+          ],
+          "Sort Key": [
+            "lineitem.l_shipmode"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 14.51,
+              "Total Cost": 27.41,
+              "Plan Rows": 1,
+              "Plan Width": 108,
+              "Actual Startup Time": 0.096,
+              "Actual Total Time": 0.102,
+              "Actual Rows": 2,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_shipmode",
+                "orders.o_orderpriority"
+              ],
+              "Inner Unique": false,
+              "Hash Cond": "(orders.o_orderkey = lineitem.l_orderkey)",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "orders",
+                  "Schema": "pg_temp",
+                  "Alias": "orders",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 12.1,
+                  "Plan Rows": 210,
+                  "Plan Width": 68,
+                  "Actual Startup Time": 0.002,
+                  "Actual Total Time": 0.007,
+                  "Actual Rows": 128,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "orders.o_orderkey",
+                    "orders.o_custkey",
+                    "orders.o_orderstatus",
+                    "orders.o_totalprice",
+                    "orders.o_orderdate",
+                    "orders.o_orderpriority",
+                    "orders.o_clerk",
+                    "orders.o_shippriority",
+                    "orders.o_comment"
+                  ]
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 14.5,
+                  "Total Cost": 14.5,
+                  "Plan Rows": 1,
+                  "Plan Width": 48,
+                  "Actual Startup Time": 0.086,
+                  "Actual Total Time": 0.087,
+                  "Actual Rows": 2,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "lineitem.l_shipmode",
+                    "lineitem.l_orderkey"
+                  ],
+                  "Hash Buckets": 1024,
+                  "Original Hash Buckets": 1024,
+                  "Hash Batches": 1,
+                  "Original Hash Batches": 1,
+                  "Peak Memory Usage": 9,
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "lineitem",
+                      "Schema": "pg_temp",
+                      "Alias": "lineitem",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 14.5,
+                      "Plan Rows": 1,
+                      "Plan Width": 48,
+                      "Actual Startup Time": 0.04,
+                      "Actual Total Time": 0.085,
+                      "Actual Rows": 2,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "lineitem.l_shipmode",
+                        "lineitem.l_orderkey"
+                      ],
+                      "Filter": "((lineitem.l_shipmode = ANY ('{MAIL,SHIP}'::bpchar[])) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01'::date) AND (lineitem.l_receiptdate < '1995-01-01'::date))",
+                      "Rows Removed by Filter": 570
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.046,
+    "Triggers": [],
+    "Execution Time": 0.122
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q13-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q13-analyze.plan.json
@@ -1,1 +1,188 @@
-[{"Plan": {"Node Type": "Sort", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 38.66, "Total Cost": 39.01, "Plan Rows": 140, "Plan Width": 16, "Actual Startup Time": 0.363, "Actual Total Time": 0.366, "Actual Rows": 2, "Actual Loops": 1, "Output": ["(count(orders.o_orderkey))", "(count(*))"], "Sort Key": ["(count(*)) DESC", "(count(orders.o_orderkey)) DESC"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Hashed", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 32.27, "Total Cost": 33.67, "Plan Rows": 140, "Plan Width": 16, "Actual Startup Time": 0.353, "Actual Total Time": 0.356, "Actual Rows": 2, "Actual Loops": 1, "Output": ["(count(orders.o_orderkey))", "count(*)"], "Group Key": ["count(orders.o_orderkey)"], "Planned Partitions": 0, "HashAgg Batches": 1, "Peak Memory Usage": 40, "Disk Usage": 0, "Plans": [{"Node Type": "Aggregate", "Strategy": "Hashed", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 28.77, "Total Cost": 30.17, "Plan Rows": 140, "Plan Width": 12, "Actual Startup Time": 0.27, "Actual Total Time": 0.309, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey", "count(orders.o_orderkey)"], "Group Key": ["customer.c_custkey"], "Planned Partitions": 0, "HashAgg Batches": 1, "Peak Memory Usage": 48, "Disk Usage": 0, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Right", "Startup Cost": 13.15, "Total Cost": 28.03, "Plan Rows": 147, "Plan Width": 8, "Actual Startup Time": 0.092, "Actual Total Time": 0.204, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey", "orders.o_orderkey"], "Inner Unique": false, "Hash Cond": "(orders.o_custkey = customer.c_custkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.62, "Plan Rows": 210, "Plan Width": 8, "Actual Startup Time": 0.009, "Actual Total Time": 0.059, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"], "Filter": "((orders.o_comment)::text !~~ '%special%requests%'::text)", "Rows Removed by Filter": 0}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 11.4, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 4, "Actual Startup Time": 0.076, "Actual Total Time": 0.077, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 13, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 4, "Actual Startup Time": 0.01, "Actual Total Time": 0.038, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey"]}]}]}]}]}]}, "Planning Time": 0.179, "Triggers": [], "Execution Time": 0.469}]
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 38.66,
+      "Total Cost": 39.01,
+      "Plan Rows": 140,
+      "Plan Width": 16,
+      "Actual Startup Time": 0.088,
+      "Actual Total Time": 0.088,
+      "Actual Rows": 2,
+      "Actual Loops": 1,
+      "Output": [
+        "(count(orders.o_orderkey))",
+        "(count(*))"
+      ],
+      "Sort Key": [
+        "(count(*)) DESC",
+        "(count(orders.o_orderkey)) DESC"
+      ],
+      "Sort Method": "quicksort",
+      "Sort Space Used": 25,
+      "Sort Space Type": "Memory",
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Hashed",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 32.27,
+          "Total Cost": 33.67,
+          "Plan Rows": 140,
+          "Plan Width": 16,
+          "Actual Startup Time": 0.083,
+          "Actual Total Time": 0.084,
+          "Actual Rows": 2,
+          "Actual Loops": 1,
+          "Output": [
+            "(count(orders.o_orderkey))",
+            "count(*)"
+          ],
+          "Group Key": [
+            "count(orders.o_orderkey)"
+          ],
+          "Planned Partitions": 0,
+          "HashAgg Batches": 1,
+          "Peak Memory Usage": 40,
+          "Disk Usage": 0,
+          "Plans": [
+            {
+              "Node Type": "Aggregate",
+              "Strategy": "Hashed",
+              "Partial Mode": "Simple",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 28.77,
+              "Total Cost": 30.17,
+              "Plan Rows": 140,
+              "Plan Width": 12,
+              "Actual Startup Time": 0.063,
+              "Actual Total Time": 0.072,
+              "Actual Rows": 129,
+              "Actual Loops": 1,
+              "Output": [
+                "customer.c_custkey",
+                "count(orders.o_orderkey)"
+              ],
+              "Group Key": [
+                "customer.c_custkey"
+              ],
+              "Planned Partitions": 0,
+              "HashAgg Batches": 1,
+              "Peak Memory Usage": 48,
+              "Disk Usage": 0,
+              "Plans": [
+                {
+                  "Node Type": "Hash Join",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Right",
+                  "Startup Cost": 13.15,
+                  "Total Cost": 28.03,
+                  "Plan Rows": 147,
+                  "Plan Width": 8,
+                  "Actual Startup Time": 0.02,
+                  "Actual Total Time": 0.049,
+                  "Actual Rows": 129,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "customer.c_custkey",
+                    "orders.o_orderkey"
+                  ],
+                  "Inner Unique": false,
+                  "Hash Cond": "(orders.o_custkey = customer.c_custkey)",
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "orders",
+                      "Schema": "pg_temp",
+                      "Alias": "orders",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 12.62,
+                      "Plan Rows": 210,
+                      "Plan Width": 8,
+                      "Actual Startup Time": 0.003,
+                      "Actual Total Time": 0.014,
+                      "Actual Rows": 128,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "orders.o_orderkey",
+                        "orders.o_custkey",
+                        "orders.o_orderstatus",
+                        "orders.o_totalprice",
+                        "orders.o_orderdate",
+                        "orders.o_orderpriority",
+                        "orders.o_clerk",
+                        "orders.o_shippriority",
+                        "orders.o_comment"
+                      ],
+                      "Filter": "((orders.o_comment)::text !~~ '%special%requests%'::text)",
+                      "Rows Removed by Filter": 0
+                    },
+                    {
+                      "Node Type": "Hash",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Startup Cost": 11.4,
+                      "Total Cost": 11.4,
+                      "Plan Rows": 140,
+                      "Plan Width": 4,
+                      "Actual Startup Time": 0.015,
+                      "Actual Total Time": 0.016,
+                      "Actual Rows": 129,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "customer.c_custkey"
+                      ],
+                      "Hash Buckets": 1024,
+                      "Original Hash Buckets": 1024,
+                      "Hash Batches": 1,
+                      "Original Hash Batches": 1,
+                      "Peak Memory Usage": 13,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "customer",
+                          "Schema": "pg_temp",
+                          "Alias": "customer",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.4,
+                          "Plan Rows": 140,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.002,
+                          "Actual Total Time": 0.009,
+                          "Actual Rows": 129,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "customer.c_custkey"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.058,
+    "Triggers": [],
+    "Execution Time": 0.103
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q14-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q14-analyze.plan.json
@@ -1,1 +1,129 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 26.46, "Total Cost": 26.48, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.125, "Actual Total Time": 0.125, "Actual Rows": 1, "Actual Loops": 1, "Output": ["((100.00 * sum(CASE WHEN ((part.p_type)::text ~~ 'PROMO%'::text) THEN (lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)) ELSE '0'::numeric END)) / sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 13.01, "Total Cost": 26.44, "Plan Rows": 1, "Plan Width": 100, "Actual Startup Time": 0.062, "Actual Total Time": 0.115, "Actual Rows": 11, "Actual Loops": 1, "Output": ["part.p_type", "lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Hash Cond": "(part.p_partkey = lineitem.l_partkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 12.76, "Plan Rows": 176, "Plan Width": 72, "Actual Startup Time": 0.003, "Actual Total Time": 0.03, "Actual Rows": 533, "Actual Loops": 1, "Output": ["part.p_partkey", "part.p_name", "part.p_mfgr", "part.p_brand", "part.p_type", "part.p_size", "part.p_container", "part.p_retailprice", "part.p_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.0, "Total Cost": 13.0, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.055, "Actual Total Time": 0.055, "Actual Rows": 11, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 13.0, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.005, "Actual Total Time": 0.052, "Actual Rows": 11, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey"], "Filter": "((lineitem.l_shipdate >= '1995-09-01'::date) AND (lineitem.l_shipdate < '1995-10-01'::date))", "Rows Removed by Filter": 561}]}]}]}, "Planning Time": 0.048, "Triggers": [], "Execution Time": 0.138}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Plain",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 26.46,
+      "Total Cost": 26.48,
+      "Plan Rows": 1,
+      "Plan Width": 32,
+      "Actual Startup Time": 0.105,
+      "Actual Total Time": 0.105,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "((100.00 * sum(CASE WHEN ((part.p_type)::text ~~ 'PROMO%'::text) THEN (lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)) ELSE '0'::numeric END)) / sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Join Type": "Inner",
+          "Startup Cost": 13.01,
+          "Total Cost": 26.44,
+          "Plan Rows": 1,
+          "Plan Width": 100,
+          "Actual Startup Time": 0.054,
+          "Actual Total Time": 0.098,
+          "Actual Rows": 11,
+          "Actual Loops": 1,
+          "Output": [
+            "part.p_type",
+            "lineitem.l_extendedprice",
+            "lineitem.l_discount"
+          ],
+          "Inner Unique": false,
+          "Hash Cond": "(part.p_partkey = lineitem.l_partkey)",
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "part",
+              "Schema": "pg_temp",
+              "Alias": "part",
+              "Startup Cost": 0.0,
+              "Total Cost": 12.76,
+              "Plan Rows": 176,
+              "Plan Width": 72,
+              "Actual Startup Time": 0.004,
+              "Actual Total Time": 0.026,
+              "Actual Rows": 533,
+              "Actual Loops": 1,
+              "Output": [
+                "part.p_partkey",
+                "part.p_name",
+                "part.p_mfgr",
+                "part.p_brand",
+                "part.p_type",
+                "part.p_size",
+                "part.p_container",
+                "part.p_retailprice",
+                "part.p_comment"
+              ]
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 13.0,
+              "Total Cost": 13.0,
+              "Plan Rows": 1,
+              "Plan Width": 36,
+              "Actual Startup Time": 0.047,
+              "Actual Total Time": 0.047,
+              "Actual Rows": 11,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount",
+                "lineitem.l_partkey"
+              ],
+              "Hash Buckets": 1024,
+              "Original Hash Buckets": 1024,
+              "Hash Batches": 1,
+              "Original Hash Batches": 1,
+              "Peak Memory Usage": 9,
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "lineitem",
+                  "Schema": "pg_temp",
+                  "Alias": "lineitem",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.0,
+                  "Plan Rows": 1,
+                  "Plan Width": 36,
+                  "Actual Startup Time": 0.005,
+                  "Actual Total Time": 0.045,
+                  "Actual Rows": 11,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount",
+                    "lineitem.l_partkey"
+                  ],
+                  "Filter": "((lineitem.l_shipdate >= '1995-09-01'::date) AND (lineitem.l_shipdate < '1995-10-01'::date))",
+                  "Rows Removed by Filter": 561
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.04,
+    "Triggers": [],
+    "Execution Time": 0.114
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q15-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q15-analyze.plan.json
@@ -1,1 +1,253 @@
-[{"Plan": {"Node Type": "Sort", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 25.19, "Total Cost": 25.19, "Plan Rows": 1, "Plan Width": 302, "Actual Startup Time": 0.376, "Actual Total Time": 0.378, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "revenue.total_revenue"], "Sort Key": ["supplier.s_suppkey"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "InitPlan", "Subplan Name": "CTE revenue", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.01, "Total Cost": 13.04, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.14, "Actual Total Time": 0.205, "Actual Rows": 50, "Actual Loops": 1, "Output": ["lineitem.l_suppkey", "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"], "Group Key": ["lineitem.l_suppkey"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.01, "Total Cost": 13.02, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.131, "Actual Total Time": 0.135, "Actual Rows": 50, "Actual Loops": 1, "Output": ["lineitem.l_suppkey", "lineitem.l_extendedprice", "lineitem.l_discount"], "Sort Key": ["lineitem.l_suppkey"], "Sort Method": "quicksort", "Sort Space Used": 28, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 13.0, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.009, "Actual Total Time": 0.112, "Actual Rows": 50, "Actual Loops": 1, "Output": ["lineitem.l_suppkey", "lineitem.l_extendedprice", "lineitem.l_discount"], "Filter": "((lineitem.l_shipdate >= '1996-01-01'::date) AND (lineitem.l_shipdate < '1996-04-01'::date))", "Rows Removed by Filter": 522}]}]}, {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "InitPlan", "Subplan Name": "InitPlan 2 (returns $1)", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.02, "Total Cost": 0.03, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.094, "Actual Total Time": 0.094, "Actual Rows": 1, "Actual Loops": 1, "Output": ["max(revenue_1.total_revenue)"], "Plans": [{"Node Type": "CTE Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "CTE Name": "revenue", "Alias": "revenue_1", "Startup Cost": 0.0, "Total Cost": 0.02, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.0, "Actual Total Time": 0.081, "Actual Rows": 50, "Actual Loops": 1, "Output": ["revenue_1.supplier_no", "revenue_1.total_revenue"]}]}, {"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 0.04, "Total Cost": 12.11, "Plan Rows": 1, "Plan Width": 302, "Actual Startup Time": 0.323, "Actual Total Time": 0.373, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "revenue.total_revenue"], "Inner Unique": false, "Hash Cond": "(supplier.s_suppkey = revenue.supplier_no)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 270, "Actual Startup Time": 0.005, "Actual Total Time": 0.057, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.02, "Total Cost": 0.02, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.253, "Actual Total Time": 0.254, "Actual Rows": 1, "Actual Loops": 1, "Output": ["revenue.total_revenue", "revenue.supplier_no"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "CTE Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "CTE Name": "revenue", "Alias": "revenue", "Startup Cost": 0.0, "Total Cost": 0.02, "Plan Rows": 1, "Plan Width": 36, "Actual Startup Time": 0.244, "Actual Total Time": 0.251, "Actual Rows": 1, "Actual Loops": 1, "Output": ["revenue.total_revenue", "revenue.supplier_no"], "Filter": "(revenue.total_revenue = $1)", "Rows Removed by Filter": 49}]}]}]}, "Planning Time": 0.154, "Triggers": [], "Execution Time": 0.416}]
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 25.19,
+      "Total Cost": 25.19,
+      "Plan Rows": 1,
+      "Plan Width": 302,
+      "Actual Startup Time": 0.137,
+      "Actual Total Time": 0.138,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "supplier.s_suppkey",
+        "supplier.s_name",
+        "supplier.s_address",
+        "supplier.s_phone",
+        "revenue.total_revenue"
+      ],
+      "Sort Key": [
+        "supplier.s_suppkey"
+      ],
+      "Sort Method": "quicksort",
+      "Sort Space Used": 25,
+      "Sort Space Type": "Memory",
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Sorted",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "InitPlan",
+          "Subplan Name": "CTE revenue",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 13.01,
+          "Total Cost": 13.04,
+          "Plan Rows": 1,
+          "Plan Width": 36,
+          "Actual Startup Time": 0.054,
+          "Actual Total Time": 0.075,
+          "Actual Rows": 50,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_suppkey",
+            "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"
+          ],
+          "Group Key": [
+            "lineitem.l_suppkey"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Sort",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 13.01,
+              "Total Cost": 13.02,
+              "Plan Rows": 1,
+              "Plan Width": 36,
+              "Actual Startup Time": 0.052,
+              "Actual Total Time": 0.053,
+              "Actual Rows": 50,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_suppkey",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount"
+              ],
+              "Sort Key": [
+                "lineitem.l_suppkey"
+              ],
+              "Sort Method": "quicksort",
+              "Sort Space Used": 26,
+              "Sort Space Type": "Memory",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "lineitem",
+                  "Schema": "pg_temp",
+                  "Alias": "lineitem",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.0,
+                  "Plan Rows": 1,
+                  "Plan Width": 36,
+                  "Actual Startup Time": 0.004,
+                  "Actual Total Time": 0.045,
+                  "Actual Rows": 50,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "lineitem.l_suppkey",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount"
+                  ],
+                  "Filter": "((lineitem.l_shipdate >= '1996-01-01'::date) AND (lineitem.l_shipdate < '1996-04-01'::date))",
+                  "Rows Removed by Filter": 522
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Plain",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "InitPlan",
+          "Subplan Name": "InitPlan 2",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 0.02,
+          "Total Cost": 0.03,
+          "Plan Rows": 1,
+          "Plan Width": 32,
+          "Actual Startup Time": 0.032,
+          "Actual Total Time": 0.032,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "max(revenue_1.total_revenue)"
+          ],
+          "Plans": [
+            {
+              "Node Type": "CTE Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "CTE Name": "revenue",
+              "Alias": "revenue_1",
+              "Startup Cost": 0.0,
+              "Total Cost": 0.02,
+              "Plan Rows": 1,
+              "Plan Width": 32,
+              "Actual Startup Time": 0.0,
+              "Actual Total Time": 0.027,
+              "Actual Rows": 50,
+              "Actual Loops": 1,
+              "Output": [
+                "revenue_1.supplier_no",
+                "revenue_1.total_revenue"
+              ]
+            }
+          ]
+        },
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Join Type": "Inner",
+          "Startup Cost": 0.04,
+          "Total Cost": 12.11,
+          "Plan Rows": 1,
+          "Plan Width": 302,
+          "Actual Startup Time": 0.117,
+          "Actual Total Time": 0.137,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "supplier.s_suppkey",
+            "supplier.s_name",
+            "supplier.s_address",
+            "supplier.s_phone",
+            "revenue.total_revenue"
+          ],
+          "Inner Unique": false,
+          "Hash Cond": "(supplier.s_suppkey = revenue.supplier_no)",
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "supplier",
+              "Schema": "pg_temp",
+              "Alias": "supplier",
+              "Startup Cost": 0.0,
+              "Total Cost": 11.5,
+              "Plan Rows": 150,
+              "Plan Width": 270,
+              "Actual Startup Time": 0.002,
+              "Actual Total Time": 0.022,
+              "Actual Rows": 518,
+              "Actual Loops": 1,
+              "Output": [
+                "supplier.s_suppkey",
+                "supplier.s_name",
+                "supplier.s_address",
+                "supplier.s_nationkey",
+                "supplier.s_phone",
+                "supplier.s_acctbal",
+                "supplier.s_comment"
+              ]
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 0.02,
+              "Total Cost": 0.02,
+              "Plan Rows": 1,
+              "Plan Width": 36,
+              "Actual Startup Time": 0.092,
+              "Actual Total Time": 0.092,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "revenue.total_revenue",
+                "revenue.supplier_no"
+              ],
+              "Hash Buckets": 1024,
+              "Original Hash Buckets": 1024,
+              "Hash Batches": 1,
+              "Original Hash Batches": 1,
+              "Peak Memory Usage": 9,
+              "Plans": [
+                {
+                  "Node Type": "CTE Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "CTE Name": "revenue",
+                  "Alias": "revenue",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 0.02,
+                  "Plan Rows": 1,
+                  "Plan Width": 36,
+                  "Actual Startup Time": 0.089,
+                  "Actual Total Time": 0.091,
+                  "Actual Rows": 1,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "revenue.total_revenue",
+                    "revenue.supplier_no"
+                  ],
+                  "Filter": "(revenue.total_revenue = (InitPlan 2).col1)",
+                  "Rows Removed by Filter": 49
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.051,
+    "Triggers": [],
+    "Execution Time": 0.15
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q16-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q16-analyze.plan.json
@@ -1,1 +1,225 @@
-[{"Plan": {"Node Type": "Sort", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 40.03, "Total Cost": 40.04, "Plan Rows": 4, "Plan Width": 124, "Actual Startup Time": 1.059, "Actual Total Time": 1.068, "Actual Rows": 81, "Actual Loops": 1, "Output": ["part.p_brand", "part.p_type", "part.p_size", "(count(DISTINCT partsupp.ps_suppkey))"], "Sort Key": ["(count(DISTINCT partsupp.ps_suppkey)) DESC", "part.p_brand", "part.p_type", "part.p_size"], "Sort Method": "quicksort", "Sort Space Used": 31, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 39.9, "Total Cost": 39.99, "Plan Rows": 4, "Plan Width": 124, "Actual Startup Time": 0.838, "Actual Total Time": 0.979, "Actual Rows": 81, "Actual Loops": 1, "Output": ["part.p_brand", "part.p_type", "part.p_size", "count(DISTINCT partsupp.ps_suppkey)"], "Group Key": ["part.p_brand", "part.p_type", "part.p_size"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 39.9, "Total Cost": 39.91, "Plan Rows": 4, "Plan Width": 120, "Actual Startup Time": 0.828, "Actual Total Time": 0.836, "Actual Rows": 81, "Actual Loops": 1, "Output": ["part.p_brand", "part.p_type", "part.p_size", "partsupp.ps_suppkey"], "Sort Key": ["part.p_brand", "part.p_type", "part.p_size"], "Sort Method": "quicksort", "Sort Space Used": 31, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 27.38, "Total Cost": 39.86, "Plan Rows": 4, "Plan Width": 120, "Actual Startup Time": 0.447, "Actual Total Time": 0.632, "Actual Rows": 81, "Actual Loops": 1, "Output": ["part.p_brand", "part.p_type", "part.p_size", "partsupp.ps_suppkey"], "Inner Unique": false, "Hash Cond": "(partsupp.ps_partkey = part.p_partkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 11.88, "Total Cost": 24.0, "Plan Rows": 85, "Plan Width": 8, "Actual Startup Time": 0.151, "Actual Total Time": 0.256, "Actual Rows": 537, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_suppkey", "partsupp.ps_availqty", "partsupp.ps_supplycost", "partsupp.ps_comment"], "Filter": "(NOT (hashed SubPlan 1))", "Rows Removed by Filter": 0, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.88, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.136, "Actual Total Time": 0.136, "Actual Rows": 0, "Actual Loops": 1, "Output": ["supplier.s_suppkey"], "Filter": "((supplier.s_comment)::text ~~ '%Customer%Complaints%'::text)", "Rows Removed by Filter": 518}]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 15.4, "Total Cost": 15.4, "Plan Rows": 8, "Plan Width": 120, "Actual Startup Time": 0.283, "Actual Total Time": 0.283, "Actual Rows": 81, "Actual Loops": 1, "Output": ["part.p_brand", "part.p_type", "part.p_size", "part.p_partkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 14, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 15.4, "Plan Rows": 8, "Plan Width": 120, "Actual Startup Time": 0.008, "Actual Total Time": 0.249, "Actual Rows": 81, "Actual Loops": 1, "Output": ["part.p_brand", "part.p_type", "part.p_size", "part.p_partkey"], "Filter": "((part.p_brand <> 'Brand#45'::bpchar) AND ((part.p_type)::text !~~ 'MEDIUM POLISHED%'::text) AND (part.p_size = ANY ('{49,14,23,45,19,3,36,9}'::integer[])))", "Rows Removed by Filter": 452}]}]}]}]}]}, "Planning Time": 0.246, "Triggers": [], "Execution Time": 1.122}]
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 40.03,
+      "Total Cost": 40.04,
+      "Plan Rows": 4,
+      "Plan Width": 124,
+      "Actual Startup Time": 0.385,
+      "Actual Total Time": 0.388,
+      "Actual Rows": 81,
+      "Actual Loops": 1,
+      "Output": [
+        "part.p_brand",
+        "part.p_type",
+        "part.p_size",
+        "(count(DISTINCT partsupp.ps_suppkey))"
+      ],
+      "Sort Key": [
+        "(count(DISTINCT partsupp.ps_suppkey)) DESC",
+        "part.p_brand",
+        "part.p_type",
+        "part.p_size"
+      ],
+      "Sort Method": "quicksort",
+      "Sort Space Used": 30,
+      "Sort Space Type": "Memory",
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Sorted",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 39.9,
+          "Total Cost": 39.99,
+          "Plan Rows": 4,
+          "Plan Width": 124,
+          "Actual Startup Time": 0.327,
+          "Actual Total Time": 0.348,
+          "Actual Rows": 81,
+          "Actual Loops": 1,
+          "Output": [
+            "part.p_brand",
+            "part.p_type",
+            "part.p_size",
+            "count(DISTINCT partsupp.ps_suppkey)"
+          ],
+          "Group Key": [
+            "part.p_brand",
+            "part.p_type",
+            "part.p_size"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Sort",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 39.9,
+              "Total Cost": 39.91,
+              "Plan Rows": 4,
+              "Plan Width": 120,
+              "Actual Startup Time": 0.324,
+              "Actual Total Time": 0.327,
+              "Actual Rows": 81,
+              "Actual Loops": 1,
+              "Output": [
+                "part.p_brand",
+                "part.p_type",
+                "part.p_size",
+                "partsupp.ps_suppkey"
+              ],
+              "Sort Key": [
+                "part.p_brand",
+                "part.p_type",
+                "part.p_size",
+                "partsupp.ps_suppkey"
+              ],
+              "Sort Method": "quicksort",
+              "Sort Space Used": 29,
+              "Sort Space Type": "Memory",
+              "Plans": [
+                {
+                  "Node Type": "Hash Join",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 27.38,
+                  "Total Cost": 39.86,
+                  "Plan Rows": 4,
+                  "Plan Width": 120,
+                  "Actual Startup Time": 0.126,
+                  "Actual Total Time": 0.181,
+                  "Actual Rows": 81,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "part.p_brand",
+                    "part.p_type",
+                    "part.p_size",
+                    "partsupp.ps_suppkey"
+                  ],
+                  "Inner Unique": false,
+                  "Hash Cond": "(partsupp.ps_partkey = part.p_partkey)",
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "partsupp",
+                      "Schema": "pg_temp",
+                      "Alias": "partsupp",
+                      "Startup Cost": 11.88,
+                      "Total Cost": 24.0,
+                      "Plan Rows": 85,
+                      "Plan Width": 8,
+                      "Actual Startup Time": 0.043,
+                      "Actual Total Time": 0.072,
+                      "Actual Rows": 537,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "partsupp.ps_partkey",
+                        "partsupp.ps_suppkey",
+                        "partsupp.ps_availqty",
+                        "partsupp.ps_supplycost",
+                        "partsupp.ps_comment"
+                      ],
+                      "Filter": "(NOT (ANY (partsupp.ps_suppkey = (hashed SubPlan 1).col1)))",
+                      "Rows Removed by Filter": 0,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "SubPlan",
+                          "Subplan Name": "SubPlan 1",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "supplier",
+                          "Schema": "pg_temp",
+                          "Alias": "supplier",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.88,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.038,
+                          "Actual Total Time": 0.038,
+                          "Actual Rows": 0,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "supplier.s_suppkey"
+                          ],
+                          "Filter": "((supplier.s_comment)::text ~~ '%Customer%Complaints%'::text)",
+                          "Rows Removed by Filter": 518
+                        }
+                      ]
+                    },
+                    {
+                      "Node Type": "Hash",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Startup Cost": 15.4,
+                      "Total Cost": 15.4,
+                      "Plan Rows": 8,
+                      "Plan Width": 120,
+                      "Actual Startup Time": 0.08,
+                      "Actual Total Time": 0.08,
+                      "Actual Rows": 81,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "part.p_brand",
+                        "part.p_type",
+                        "part.p_size",
+                        "part.p_partkey"
+                      ],
+                      "Hash Buckets": 1024,
+                      "Original Hash Buckets": 1024,
+                      "Hash Batches": 1,
+                      "Original Hash Batches": 1,
+                      "Peak Memory Usage": 14,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "part",
+                          "Schema": "pg_temp",
+                          "Alias": "part",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 15.4,
+                          "Plan Rows": 8,
+                          "Plan Width": 120,
+                          "Actual Startup Time": 0.003,
+                          "Actual Total Time": 0.071,
+                          "Actual Rows": 81,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "part.p_brand",
+                            "part.p_type",
+                            "part.p_size",
+                            "part.p_partkey"
+                          ],
+                          "Filter": "((part.p_brand <> 'Brand#45'::bpchar) AND ((part.p_type)::text !~~ 'MEDIUM POLISHED%'::text) AND (part.p_size = ANY ('{49,14,23,45,19,3,36,9}'::integer[])))",
+                          "Rows Removed by Filter": 452
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.055,
+    "Triggers": [],
+    "Execution Time": 0.403
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q17-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q17-analyze.plan.json
@@ -1,1 +1,191 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 38.94, "Total Cost": 38.95, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 4.156, "Actual Total Time": 4.158, "Actual Rows": 1, "Actual Loops": 1, "Output": ["(sum(lineitem.l_extendedprice) / 7.0)"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 13.65, "Total Cost": 38.93, "Plan Rows": 1, "Plan Width": 16, "Actual Startup Time": 1.234, "Actual Total Time": 4.153, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice"], "Inner Unique": false, "Hash Cond": "(lineitem.l_partkey = part.p_partkey)", "Join Filter": "(lineitem.l_quantity < (SubPlan 1))", "Rows Removed by Join Filter": 39, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 36, "Actual Startup Time": 0.007, "Actual Total Time": 0.081, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.64, "Total Cost": 13.64, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.131, "Actual Total Time": 0.132, "Actual Rows": 3, "Actual Loops": 1, "Output": ["part.p_partkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 13.64, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.008, "Actual Total Time": 0.128, "Actual Rows": 3, "Actual Loops": 1, "Output": ["part.p_partkey"], "Filter": "((part.p_brand = 'Brand#23'::bpchar) AND (part.p_container = 'MED BOX'::bpchar))", "Rows Removed by Filter": 530}]}, {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.5, "Total Cost": 12.52, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.093, "Actual Total Time": 0.093, "Actual Rows": 1, "Actual Loops": 41, "Output": ["(0.2 * avg(lineitem_1.l_quantity))"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem_1", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 1, "Plan Width": 16, "Actual Startup Time": 0.005, "Actual Total Time": 0.082, "Actual Rows": 37, "Actual Loops": 41, "Output": ["lineitem_1.l_orderkey", "lineitem_1.l_partkey", "lineitem_1.l_suppkey", "lineitem_1.l_linenumber", "lineitem_1.l_quantity", "lineitem_1.l_extendedprice", "lineitem_1.l_discount", "lineitem_1.l_tax", "lineitem_1.l_returnflag", "lineitem_1.l_linestatus", "lineitem_1.l_shipdate", "lineitem_1.l_commitdate", "lineitem_1.l_receiptdate", "lineitem_1.l_shipinstruct", "lineitem_1.l_shipmode", "lineitem_1.l_comment"], "Filter": "(lineitem_1.l_partkey = part.p_partkey)", "Rows Removed by Filter": 535}]}]}]}, "Planning Time": 0.143, "Triggers": [], "Execution Time": 4.198}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Plain",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 38.94,
+      "Total Cost": 38.95,
+      "Plan Rows": 1,
+      "Plan Width": 32,
+      "Actual Startup Time": 1.256,
+      "Actual Total Time": 1.257,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "(sum(lineitem.l_extendedprice) / 7.0)"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Join Type": "Inner",
+          "Startup Cost": 13.65,
+          "Total Cost": 38.93,
+          "Plan Rows": 1,
+          "Plan Width": 16,
+          "Actual Startup Time": 0.358,
+          "Actual Total Time": 1.255,
+          "Actual Rows": 2,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_extendedprice"
+          ],
+          "Inner Unique": false,
+          "Hash Cond": "(lineitem.l_partkey = part.p_partkey)",
+          "Join Filter": "(lineitem.l_quantity < (SubPlan 1))",
+          "Rows Removed by Join Filter": 39,
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "lineitem",
+              "Schema": "pg_temp",
+              "Alias": "lineitem",
+              "Startup Cost": 0.0,
+              "Total Cost": 12.0,
+              "Plan Rows": 200,
+              "Plan Width": 36,
+              "Actual Startup Time": 0.002,
+              "Actual Total Time": 0.035,
+              "Actual Rows": 572,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_orderkey",
+                "lineitem.l_partkey",
+                "lineitem.l_suppkey",
+                "lineitem.l_linenumber",
+                "lineitem.l_quantity",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount",
+                "lineitem.l_tax",
+                "lineitem.l_returnflag",
+                "lineitem.l_linestatus",
+                "lineitem.l_shipdate",
+                "lineitem.l_commitdate",
+                "lineitem.l_receiptdate",
+                "lineitem.l_shipinstruct",
+                "lineitem.l_shipmode",
+                "lineitem.l_comment"
+              ]
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 13.64,
+              "Total Cost": 13.64,
+              "Plan Rows": 1,
+              "Plan Width": 4,
+              "Actual Startup Time": 0.041,
+              "Actual Total Time": 0.041,
+              "Actual Rows": 3,
+              "Actual Loops": 1,
+              "Output": [
+                "part.p_partkey"
+              ],
+              "Hash Buckets": 1024,
+              "Original Hash Buckets": 1024,
+              "Hash Batches": 1,
+              "Original Hash Batches": 1,
+              "Peak Memory Usage": 9,
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "part",
+                  "Schema": "pg_temp",
+                  "Alias": "part",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.64,
+                  "Plan Rows": 1,
+                  "Plan Width": 4,
+                  "Actual Startup Time": 0.002,
+                  "Actual Total Time": 0.04,
+                  "Actual Rows": 3,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "part.p_partkey"
+                  ],
+                  "Filter": "((part.p_brand = 'Brand#23'::bpchar) AND (part.p_container = 'MED BOX'::bpchar))",
+                  "Rows Removed by Filter": 530
+                }
+              ]
+            },
+            {
+              "Node Type": "Aggregate",
+              "Strategy": "Plain",
+              "Partial Mode": "Simple",
+              "Parent Relationship": "SubPlan",
+              "Subplan Name": "SubPlan 1",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 12.5,
+              "Total Cost": 12.52,
+              "Plan Rows": 1,
+              "Plan Width": 32,
+              "Actual Startup Time": 0.028,
+              "Actual Total Time": 0.028,
+              "Actual Rows": 1,
+              "Actual Loops": 41,
+              "Output": [
+                "(0.2 * avg(lineitem_1.l_quantity))"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "lineitem",
+                  "Schema": "pg_temp",
+                  "Alias": "lineitem_1",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 12.5,
+                  "Plan Rows": 1,
+                  "Plan Width": 16,
+                  "Actual Startup Time": 0.001,
+                  "Actual Total Time": 0.024,
+                  "Actual Rows": 37,
+                  "Actual Loops": 41,
+                  "Output": [
+                    "lineitem_1.l_orderkey",
+                    "lineitem_1.l_partkey",
+                    "lineitem_1.l_suppkey",
+                    "lineitem_1.l_linenumber",
+                    "lineitem_1.l_quantity",
+                    "lineitem_1.l_extendedprice",
+                    "lineitem_1.l_discount",
+                    "lineitem_1.l_tax",
+                    "lineitem_1.l_returnflag",
+                    "lineitem_1.l_linestatus",
+                    "lineitem_1.l_shipdate",
+                    "lineitem_1.l_commitdate",
+                    "lineitem_1.l_receiptdate",
+                    "lineitem_1.l_shipinstruct",
+                    "lineitem_1.l_shipmode",
+                    "lineitem_1.l_comment"
+                  ],
+                  "Filter": "(lineitem_1.l_partkey = part.p_partkey)",
+                  "Rows Removed by Filter": 535
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.035,
+    "Triggers": [],
+    "Execution Time": 1.267
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q18-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q18-analyze.plan.json
@@ -1,1 +1,404 @@
-[{"Plan": {"Node Type": "Limit", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 60.3, "Total Cost": 61.77, "Plan Rows": 49, "Plan Width": 128, "Actual Startup Time": 1.144, "Actual Total Time": 1.157, "Actual Rows": 2, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey", "orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "(sum(lineitem.l_quantity))"], "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 60.3, "Total Cost": 61.77, "Plan Rows": 49, "Plan Width": 128, "Actual Startup Time": 1.142, "Actual Total Time": 1.154, "Actual Rows": 2, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey", "orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "sum(lineitem.l_quantity)"], "Group Key": ["orders.o_totalprice", "orders.o_orderdate", "customer.c_name", "customer.c_custkey", "orders.o_orderkey"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 60.3, "Total Cost": 60.42, "Plan Rows": 49, "Plan Width": 112, "Actual Startup Time": 1.126, "Actual Total Time": 1.132, "Actual Rows": 14, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey", "orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "lineitem.l_quantity"], "Sort Key": ["orders.o_totalprice DESC", "orders.o_orderdate", "customer.c_name", "customer.c_custkey", "orders.o_orderkey"], "Sort Method": "quicksort", "Sort Space Used": 26, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 44.68, "Total Cost": 58.92, "Plan Rows": 49, "Plan Width": 112, "Actual Startup Time": 0.942, "Actual Total Time": 1.038, "Actual Rows": 14, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey", "orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "lineitem.l_quantity"], "Inner Unique": false, "Hash Cond": "(lineitem.l_orderkey = orders.o_orderkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 20, "Actual Startup Time": 0.007, "Actual Total Time": 0.103, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 44.07, "Total Cost": 44.07, "Plan Rows": 49, "Plan Width": 100, "Actual Startup Time": 0.81, "Actual Total Time": 0.813, "Actual Rows": 2, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey", "orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "lineitem_1.l_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 30.66, "Total Cost": 44.07, "Plan Rows": 49, "Plan Width": 100, "Actual Startup Time": 0.782, "Actual Total Time": 0.806, "Actual Rows": 2, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey", "orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "lineitem_1.l_orderkey"], "Inner Unique": false, "Hash Cond": "(orders.o_custkey = customer.c_custkey)", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 17.51, "Total Cost": 30.17, "Plan Rows": 70, "Plan Width": 32, "Actual Startup Time": 0.662, "Actual Total Time": 0.683, "Actual Rows": 2, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_orderdate", "orders.o_totalprice", "orders.o_custkey", "lineitem_1.l_orderkey"], "Inner Unique": true, "Hash Cond": "(orders.o_orderkey = lineitem_1.l_orderkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.1, "Plan Rows": 210, "Plan Width": 28, "Actual Startup Time": 0.004, "Actual Total Time": 0.024, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 16.67, "Total Cost": 16.67, "Plan Rows": 67, "Plan Width": 4, "Actual Startup Time": 0.61, "Actual Total Time": 0.611, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem_1.l_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Aggregate", "Strategy": "Hashed", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.0, "Total Cost": 16.0, "Plan Rows": 67, "Plan Width": 4, "Actual Startup Time": 0.565, "Actual Total Time": 0.606, "Actual Rows": 2, "Actual Loops": 1, "Output": ["lineitem_1.l_orderkey"], "Group Key": ["lineitem_1.l_orderkey"], "Filter": "(sum(lineitem_1.l_quantity) > '300'::numeric)", "Planned Partitions": 0, "HashAgg Batches": 1, "Peak Memory Usage": 96, "Disk Usage": 0, "Rows Removed by Filter": 126, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem_1", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 20, "Actual Startup Time": 0.004, "Actual Total Time": 0.106, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem_1.l_orderkey", "lineitem_1.l_partkey", "lineitem_1.l_suppkey", "lineitem_1.l_linenumber", "lineitem_1.l_quantity", "lineitem_1.l_extendedprice", "lineitem_1.l_discount", "lineitem_1.l_tax", "lineitem_1.l_returnflag", "lineitem_1.l_linestatus", "lineitem_1.l_shipdate", "lineitem_1.l_commitdate", "lineitem_1.l_receiptdate", "lineitem_1.l_shipinstruct", "lineitem_1.l_shipmode", "lineitem_1.l_comment"]}]}]}]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 11.4, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 72, "Actual Startup Time": 0.094, "Actual Total Time": 0.094, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 16, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 72, "Actual Startup Time": 0.005, "Actual Total Time": 0.037, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_name", "customer.c_custkey"]}]}]}]}]}]}]}]}, "Planning Time": 0.62, "Triggers": [], "Execution Time": 1.272}]
+[
+  {
+    "Plan": {
+      "Node Type": "Limit",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 59.63,
+      "Total Cost": 61.1,
+      "Plan Rows": 49,
+      "Plan Width": 128,
+      "Actual Startup Time": 0.233,
+      "Actual Total Time": 0.236,
+      "Actual Rows": 2,
+      "Actual Loops": 1,
+      "Output": [
+        "customer.c_name",
+        "customer.c_custkey",
+        "orders.o_orderkey",
+        "orders.o_orderdate",
+        "orders.o_totalprice",
+        "(sum(lineitem.l_quantity))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Sorted",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 59.63,
+          "Total Cost": 61.1,
+          "Plan Rows": 49,
+          "Plan Width": 128,
+          "Actual Startup Time": 0.233,
+          "Actual Total Time": 0.235,
+          "Actual Rows": 2,
+          "Actual Loops": 1,
+          "Output": [
+            "customer.c_name",
+            "customer.c_custkey",
+            "orders.o_orderkey",
+            "orders.o_orderdate",
+            "orders.o_totalprice",
+            "sum(lineitem.l_quantity)"
+          ],
+          "Group Key": [
+            "orders.o_totalprice",
+            "orders.o_orderdate",
+            "customer.c_name",
+            "customer.c_custkey",
+            "orders.o_orderkey"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Sort",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 59.63,
+              "Total Cost": 59.75,
+              "Plan Rows": 49,
+              "Plan Width": 112,
+              "Actual Startup Time": 0.229,
+              "Actual Total Time": 0.23,
+              "Actual Rows": 14,
+              "Actual Loops": 1,
+              "Output": [
+                "customer.c_name",
+                "customer.c_custkey",
+                "orders.o_orderkey",
+                "orders.o_orderdate",
+                "orders.o_totalprice",
+                "lineitem.l_quantity"
+              ],
+              "Sort Key": [
+                "orders.o_totalprice DESC",
+                "orders.o_orderdate",
+                "customer.c_name",
+                "customer.c_custkey",
+                "orders.o_orderkey"
+              ],
+              "Sort Method": "quicksort",
+              "Sort Space Used": 25,
+              "Sort Space Type": "Memory",
+              "Plans": [
+                {
+                  "Node Type": "Hash Join",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 44.01,
+                  "Total Cost": 58.25,
+                  "Plan Rows": 49,
+                  "Plan Width": 112,
+                  "Actual Startup Time": 0.198,
+                  "Actual Total Time": 0.22,
+                  "Actual Rows": 14,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "customer.c_name",
+                    "customer.c_custkey",
+                    "orders.o_orderkey",
+                    "orders.o_orderdate",
+                    "orders.o_totalprice",
+                    "lineitem.l_quantity"
+                  ],
+                  "Inner Unique": false,
+                  "Hash Cond": "(lineitem.l_orderkey = orders.o_orderkey)",
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "lineitem",
+                      "Schema": "pg_temp",
+                      "Alias": "lineitem",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 12.0,
+                      "Plan Rows": 200,
+                      "Plan Width": 20,
+                      "Actual Startup Time": 0.002,
+                      "Actual Total Time": 0.025,
+                      "Actual Rows": 572,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "lineitem.l_orderkey",
+                        "lineitem.l_partkey",
+                        "lineitem.l_suppkey",
+                        "lineitem.l_linenumber",
+                        "lineitem.l_quantity",
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount",
+                        "lineitem.l_tax",
+                        "lineitem.l_returnflag",
+                        "lineitem.l_linestatus",
+                        "lineitem.l_shipdate",
+                        "lineitem.l_commitdate",
+                        "lineitem.l_receiptdate",
+                        "lineitem.l_shipinstruct",
+                        "lineitem.l_shipmode",
+                        "lineitem.l_comment"
+                      ]
+                    },
+                    {
+                      "Node Type": "Hash",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Startup Cost": 43.4,
+                      "Total Cost": 43.4,
+                      "Plan Rows": 49,
+                      "Plan Width": 100,
+                      "Actual Startup Time": 0.169,
+                      "Actual Total Time": 0.169,
+                      "Actual Rows": 2,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "customer.c_name",
+                        "customer.c_custkey",
+                        "orders.o_orderkey",
+                        "orders.o_orderdate",
+                        "orders.o_totalprice",
+                        "lineitem_1.l_orderkey"
+                      ],
+                      "Hash Buckets": 1024,
+                      "Original Hash Buckets": 1024,
+                      "Hash Batches": 1,
+                      "Original Hash Batches": 1,
+                      "Peak Memory Usage": 9,
+                      "Plans": [
+                        {
+                          "Node Type": "Hash Join",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Join Type": "Inner",
+                          "Startup Cost": 29.99,
+                          "Total Cost": 43.4,
+                          "Plan Rows": 49,
+                          "Plan Width": 100,
+                          "Actual Startup Time": 0.163,
+                          "Actual Total Time": 0.168,
+                          "Actual Rows": 2,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "customer.c_name",
+                            "customer.c_custkey",
+                            "orders.o_orderkey",
+                            "orders.o_orderdate",
+                            "orders.o_totalprice",
+                            "lineitem_1.l_orderkey"
+                          ],
+                          "Inner Unique": false,
+                          "Hash Cond": "(orders.o_custkey = customer.c_custkey)",
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 16.84,
+                              "Total Cost": 29.5,
+                              "Plan Rows": 70,
+                              "Plan Width": 32,
+                              "Actual Startup Time": 0.144,
+                              "Actual Total Time": 0.148,
+                              "Actual Rows": 2,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "orders.o_orderkey",
+                                "orders.o_orderdate",
+                                "orders.o_totalprice",
+                                "orders.o_custkey",
+                                "lineitem_1.l_orderkey"
+                              ],
+                              "Inner Unique": true,
+                              "Hash Cond": "(orders.o_orderkey = lineitem_1.l_orderkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "orders",
+                                  "Schema": "pg_temp",
+                                  "Alias": "orders",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 12.1,
+                                  "Plan Rows": 210,
+                                  "Plan Width": 28,
+                                  "Actual Startup Time": 0.001,
+                                  "Actual Total Time": 0.006,
+                                  "Actual Rows": 128,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "orders.o_orderkey",
+                                    "orders.o_custkey",
+                                    "orders.o_orderstatus",
+                                    "orders.o_totalprice",
+                                    "orders.o_orderdate",
+                                    "orders.o_orderpriority",
+                                    "orders.o_clerk",
+                                    "orders.o_shippriority",
+                                    "orders.o_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 16.0,
+                                  "Total Cost": 16.0,
+                                  "Plan Rows": 67,
+                                  "Plan Width": 4,
+                                  "Actual Startup Time": 0.135,
+                                  "Actual Total Time": 0.135,
+                                  "Actual Rows": 2,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "lineitem_1.l_orderkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 9,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Aggregate",
+                                      "Strategy": "Hashed",
+                                      "Partial Mode": "Simple",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Startup Cost": 13.0,
+                                      "Total Cost": 16.0,
+                                      "Plan Rows": 67,
+                                      "Plan Width": 4,
+                                      "Actual Startup Time": 0.126,
+                                      "Actual Total Time": 0.134,
+                                      "Actual Rows": 2,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "lineitem_1.l_orderkey"
+                                      ],
+                                      "Group Key": [
+                                        "lineitem_1.l_orderkey"
+                                      ],
+                                      "Filter": "(sum(lineitem_1.l_quantity) > '300'::numeric)",
+                                      "Planned Partitions": 0,
+                                      "HashAgg Batches": 1,
+                                      "Peak Memory Usage": 96,
+                                      "Disk Usage": 0,
+                                      "Rows Removed by Filter": 126,
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "lineitem",
+                                          "Schema": "pg_temp",
+                                          "Alias": "lineitem_1",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 12.0,
+                                          "Plan Rows": 200,
+                                          "Plan Width": 20,
+                                          "Actual Startup Time": 0.001,
+                                          "Actual Total Time": 0.025,
+                                          "Actual Rows": 572,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "lineitem_1.l_orderkey",
+                                            "lineitem_1.l_partkey",
+                                            "lineitem_1.l_suppkey",
+                                            "lineitem_1.l_linenumber",
+                                            "lineitem_1.l_quantity",
+                                            "lineitem_1.l_extendedprice",
+                                            "lineitem_1.l_discount",
+                                            "lineitem_1.l_tax",
+                                            "lineitem_1.l_returnflag",
+                                            "lineitem_1.l_linestatus",
+                                            "lineitem_1.l_shipdate",
+                                            "lineitem_1.l_commitdate",
+                                            "lineitem_1.l_receiptdate",
+                                            "lineitem_1.l_shipinstruct",
+                                            "lineitem_1.l_shipmode",
+                                            "lineitem_1.l_comment"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Node Type": "Hash",
+                              "Parent Relationship": "Inner",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 11.4,
+                              "Total Cost": 11.4,
+                              "Plan Rows": 140,
+                              "Plan Width": 72,
+                              "Actual Startup Time": 0.018,
+                              "Actual Total Time": 0.018,
+                              "Actual Rows": 129,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "customer.c_name",
+                                "customer.c_custkey"
+                              ],
+                              "Hash Buckets": 1024,
+                              "Original Hash Buckets": 1024,
+                              "Hash Batches": 1,
+                              "Original Hash Batches": 1,
+                              "Peak Memory Usage": 16,
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "customer",
+                                  "Schema": "pg_temp",
+                                  "Alias": "customer",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.4,
+                                  "Plan Rows": 140,
+                                  "Plan Width": 72,
+                                  "Actual Startup Time": 0.002,
+                                  "Actual Total Time": 0.01,
+                                  "Actual Rows": 129,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "customer.c_name",
+                                    "customer.c_custkey"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.132,
+    "Triggers": [],
+    "Execution Time": 0.256
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q19-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q19-analyze.plan.json
@@ -1,1 +1,118 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 34.55, "Total Cost": 34.56, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 2.468, "Actual Total Time": 2.469, "Actual Rows": 1, "Actual Loops": 1, "Output": ["sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"], "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 0.0, "Total Cost": 34.54, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.232, "Actual Total Time": 2.461, "Actual Rows": 1, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Join Filter": "((lineitem.l_partkey = part.p_partkey) AND (((part.p_brand = 'Brand#12'::bpchar) AND (part.p_container = ANY ('{\"SM CASE\",\"SM BOX\",\"SM PACK\",\"SM PKG\"}'::bpchar[])) AND (lineitem.l_quantity >= '1'::numeric) AND (lineitem.l_quantity <= '11'::numeric) AND (part.p_size <= 5)) OR ((part.p_brand = 'Brand#23'::bpchar) AND (part.p_container = ANY ('{\"MED BAG\",\"MED BOX\",\"MED PKG\",\"MED PACK\"}'::bpchar[])) AND (lineitem.l_quantity >= '10'::numeric) AND (lineitem.l_quantity <= '20'::numeric) AND (part.p_size <= 10)) OR ((part.p_brand = 'Brand#34'::bpchar) AND (part.p_container = ANY ('{\"LG CASE\",\"LG BOX\",\"LG PACK\",\"LG PKG\"}'::bpchar[])) AND (lineitem.l_quantity >= '20'::numeric) AND (lineitem.l_quantity <= '30'::numeric) AND (part.p_size <= 15))))", "Rows Removed by Join Filter": 35, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 16.0, "Plan Rows": 1, "Plan Width": 52, "Actual Startup Time": 0.025, "Actual Total Time": 0.194, "Actual Rows": 12, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "((lineitem.l_shipmode = ANY ('{AIR,\"AIR REG\"}'::bpchar[])) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON'::bpchar) AND (((lineitem.l_quantity >= '1'::numeric) AND (lineitem.l_quantity <= '11'::numeric)) OR ((lineitem.l_quantity >= '10'::numeric) AND (lineitem.l_quantity <= '20'::numeric)) OR ((lineitem.l_quantity >= '20'::numeric) AND (lineitem.l_quantity <= '30'::numeric))))", "Rows Removed by Filter": 560}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 18.48, "Plan Rows": 1, "Plan Width": 96, "Actual Startup Time": 0.003, "Actual Total Time": 0.187, "Actual Rows": 3, "Actual Loops": 12, "Output": ["part.p_partkey", "part.p_name", "part.p_mfgr", "part.p_brand", "part.p_type", "part.p_size", "part.p_container", "part.p_retailprice", "part.p_comment"], "Filter": "((part.p_size >= 1) AND (((part.p_brand = 'Brand#12'::bpchar) AND (part.p_container = ANY ('{\"SM CASE\",\"SM BOX\",\"SM PACK\",\"SM PKG\"}'::bpchar[])) AND (part.p_size <= 5)) OR ((part.p_brand = 'Brand#23'::bpchar) AND (part.p_container = ANY ('{\"MED BAG\",\"MED BOX\",\"MED PKG\",\"MED PACK\"}'::bpchar[])) AND (part.p_size <= 10)) OR ((part.p_brand = 'Brand#34'::bpchar) AND (part.p_container = ANY ('{\"LG CASE\",\"LG BOX\",\"LG PACK\",\"LG PKG\"}'::bpchar[])) AND (part.p_size <= 15))))", "Rows Removed by Filter": 530}]}]}, "Planning Time": 0.179, "Triggers": [], "Execution Time": 2.501}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Plain",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 34.55,
+      "Total Cost": 34.56,
+      "Plan Rows": 1,
+      "Plan Width": 32,
+      "Actual Startup Time": 1.03,
+      "Actual Total Time": 1.03,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Nested Loop",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Join Type": "Inner",
+          "Startup Cost": 0.0,
+          "Total Cost": 34.54,
+          "Plan Rows": 1,
+          "Plan Width": 32,
+          "Actual Startup Time": 0.092,
+          "Actual Total Time": 1.027,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_extendedprice",
+            "lineitem.l_discount"
+          ],
+          "Inner Unique": false,
+          "Join Filter": "((lineitem.l_partkey = part.p_partkey) AND (((part.p_brand = 'Brand#12'::bpchar) AND (part.p_container = ANY ('{\"SM CASE\",\"SM BOX\",\"SM PACK\",\"SM PKG\"}'::bpchar[])) AND (lineitem.l_quantity >= '1'::numeric) AND (lineitem.l_quantity <= '11'::numeric) AND (part.p_size <= 5)) OR ((part.p_brand = 'Brand#23'::bpchar) AND (part.p_container = ANY ('{\"MED BAG\",\"MED BOX\",\"MED PKG\",\"MED PACK\"}'::bpchar[])) AND (lineitem.l_quantity >= '10'::numeric) AND (lineitem.l_quantity <= '20'::numeric) AND (part.p_size <= 10)) OR ((part.p_brand = 'Brand#34'::bpchar) AND (part.p_container = ANY ('{\"LG CASE\",\"LG BOX\",\"LG PACK\",\"LG PKG\"}'::bpchar[])) AND (lineitem.l_quantity >= '20'::numeric) AND (lineitem.l_quantity <= '30'::numeric) AND (part.p_size <= 15))))",
+          "Rows Removed by Join Filter": 35,
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "lineitem",
+              "Schema": "pg_temp",
+              "Alias": "lineitem",
+              "Startup Cost": 0.0,
+              "Total Cost": 16.0,
+              "Plan Rows": 1,
+              "Plan Width": 52,
+              "Actual Startup Time": 0.011,
+              "Actual Total Time": 0.106,
+              "Actual Rows": 12,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_orderkey",
+                "lineitem.l_partkey",
+                "lineitem.l_suppkey",
+                "lineitem.l_linenumber",
+                "lineitem.l_quantity",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount",
+                "lineitem.l_tax",
+                "lineitem.l_returnflag",
+                "lineitem.l_linestatus",
+                "lineitem.l_shipdate",
+                "lineitem.l_commitdate",
+                "lineitem.l_receiptdate",
+                "lineitem.l_shipinstruct",
+                "lineitem.l_shipmode",
+                "lineitem.l_comment"
+              ],
+              "Filter": "((lineitem.l_shipmode = ANY ('{AIR,\"AIR REG\"}'::bpchar[])) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON'::bpchar) AND (((lineitem.l_quantity >= '1'::numeric) AND (lineitem.l_quantity <= '11'::numeric)) OR ((lineitem.l_quantity >= '10'::numeric) AND (lineitem.l_quantity <= '20'::numeric)) OR ((lineitem.l_quantity >= '20'::numeric) AND (lineitem.l_quantity <= '30'::numeric))))",
+              "Rows Removed by Filter": 560
+            },
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "part",
+              "Schema": "pg_temp",
+              "Alias": "part",
+              "Startup Cost": 0.0,
+              "Total Cost": 18.48,
+              "Plan Rows": 1,
+              "Plan Width": 96,
+              "Actual Startup Time": 0.002,
+              "Actual Total Time": 0.076,
+              "Actual Rows": 3,
+              "Actual Loops": 12,
+              "Output": [
+                "part.p_partkey",
+                "part.p_name",
+                "part.p_mfgr",
+                "part.p_brand",
+                "part.p_type",
+                "part.p_size",
+                "part.p_container",
+                "part.p_retailprice",
+                "part.p_comment"
+              ],
+              "Filter": "((part.p_size >= 1) AND (((part.p_brand = 'Brand#12'::bpchar) AND (part.p_container = ANY ('{\"SM CASE\",\"SM BOX\",\"SM PACK\",\"SM PKG\"}'::bpchar[])) AND (part.p_size <= 5)) OR ((part.p_brand = 'Brand#23'::bpchar) AND (part.p_container = ANY ('{\"MED BAG\",\"MED BOX\",\"MED PKG\",\"MED PACK\"}'::bpchar[])) AND (part.p_size <= 10)) OR ((part.p_brand = 'Brand#34'::bpchar) AND (part.p_container = ANY ('{\"LG CASE\",\"LG BOX\",\"LG PACK\",\"LG PKG\"}'::bpchar[])) AND (part.p_size <= 15))))",
+              "Rows Removed by Filter": 530
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.063,
+    "Triggers": [],
+    "Execution Time": 1.041
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q2-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q2-analyze.plan.json
@@ -1,1 +1,648 @@
-[{"Plan": {"Node Type": "Limit", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 86.97, "Total Cost": 86.98, "Plan Rows": 1, "Plan Width": 714, "Actual Startup Time": 2.244, "Actual Total Time": 2.25, "Actual Rows": 2, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "nation.n_name", "part.p_partkey", "part.p_mfgr", "supplier.s_address", "supplier.s_phone", "supplier.s_comment"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 86.97, "Total Cost": 86.98, "Plan Rows": 1, "Plan Width": 714, "Actual Startup Time": 2.243, "Actual Total Time": 2.248, "Actual Rows": 2, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "nation.n_name", "part.p_partkey", "part.p_mfgr", "supplier.s_address", "supplier.s_phone", "supplier.s_comment"], "Sort Key": ["supplier.s_acctbal DESC", "nation.n_name", "supplier.s_name", "part.p_partkey"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 48.95, "Total Cost": 86.96, "Plan Rows": 1, "Plan Width": 714, "Actual Startup Time": 1.03, "Actual Total Time": 2.239, "Actual Rows": 2, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "nation.n_name", "part.p_partkey", "part.p_mfgr", "supplier.s_address", "supplier.s_phone", "supplier.s_comment"], "Inner Unique": false, "Hash Cond": "((part.p_partkey = partsupp.ps_partkey) AND ((SubPlan 1) = partsupp.ps_supplycost))", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 13.64, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.036, "Actual Total Time": 0.15, "Actual Rows": 6, "Actual Loops": 1, "Output": ["part.p_partkey", "part.p_name", "part.p_mfgr", "part.p_brand", "part.p_type", "part.p_size", "part.p_container", "part.p_retailprice", "part.p_comment"], "Filter": "(((part.p_type)::text ~~ '%BRASS'::text) AND (part.p_size = 15))", "Rows Removed by Filter": 527}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 48.93, "Total Cost": 48.93, "Plan Rows": 1, "Plan Width": 626, "Actual Startup Time": 0.499, "Actual Total Time": 0.501, "Actual Rows": 95, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "partsupp.ps_partkey", "partsupp.ps_supplycost", "nation.n_name"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 22, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 36.58, "Total Cost": 48.93, "Plan Rows": 1, "Plan Width": 626, "Actual Startup Time": 0.256, "Actual Total Time": 0.436, "Actual Rows": 95, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "partsupp.ps_partkey", "partsupp.ps_supplycost", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(partsupp.ps_suppkey = supplier.s_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 24, "Actual Startup Time": 0.005, "Actual Total Time": 0.071, "Actual Rows": 537, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_suppkey", "partsupp.ps_availqty", "partsupp.ps_supplycost", "partsupp.ps_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 36.57, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 610, "Actual Startup Time": 0.246, "Actual Total Time": 0.247, "Actual Rows": 90, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "supplier.s_suppkey", "nation.n_name"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 21, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.5, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 610, "Actual Startup Time": 0.032, "Actual Total Time": 0.206, "Actual Rows": 90, "Actual Loops": 1, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "supplier.s_suppkey", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 510, "Actual Startup Time": 0.003, "Actual Total Time": 0.069, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.48, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.023, "Actual Total Time": 0.024, "Actual Rows": 5, "Actual Loops": 1, "Output": ["nation.n_name", "nation.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.014, "Actual Total Time": 0.021, "Actual Rows": 5, "Actual Loops": 1, "Output": ["nation.n_name", "nation.n_nationkey"], "Inner Unique": false, "Hash Cond": "(nation.n_regionkey = region.r_regionkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 112, "Actual Startup Time": 0.002, "Actual Total Time": 0.004, "Actual Rows": 25, "Actual Loops": 1, "Output": ["nation.n_nationkey", "nation.n_name", "nation.n_regionkey", "nation.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.006, "Actual Total Time": 0.007, "Actual Rows": 1, "Actual Loops": 1, "Output": ["region.r_regionkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.003, "Actual Total Time": 0.004, "Actual Rows": 1, "Actual Loops": 1, "Output": ["region.r_regionkey"], "Filter": "(region.r_name = 'EUROPE'::bpchar)", "Rows Removed by Filter": 4}]}]}]}]}]}]}]}, {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 48.71, "Total Cost": 48.72, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.196, "Actual Total Time": 0.196, "Actual Rows": 1, "Actual Loops": 8, "Output": ["min(partsupp_1.ps_supplycost)"], "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.22, "Total Cost": 48.71, "Plan Rows": 1, "Plan Width": 16, "Actual Startup Time": 0.192, "Actual Total Time": 0.195, "Actual Rows": 0, "Actual Loops": 8, "Output": ["partsupp_1.ps_supplycost"], "Inner Unique": false, "Join Filter": "(nation_1.n_regionkey = region_1.r_regionkey)", "Rows Removed by Join Filter": 0, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.22, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 20, "Actual Startup Time": 0.187, "Actual Total Time": 0.191, "Actual Rows": 1, "Actual Loops": 8, "Output": ["partsupp_1.ps_supplycost", "nation_1.n_regionkey"], "Inner Unique": false, "Hash Cond": "(nation_1.n_nationkey = supplier_1.s_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation_1", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.003, "Actual Rows": 25, "Actual Loops": 8, "Output": ["nation_1.n_nationkey", "nation_1.n_name", "nation_1.n_regionkey", "nation_1.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.21, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 20, "Actual Startup Time": 0.182, "Actual Total Time": 0.182, "Actual Rows": 1, "Actual Loops": 8, "Output": ["partsupp_1.ps_supplycost", "supplier_1.s_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 20, "Actual Startup Time": 0.131, "Actual Total Time": 0.181, "Actual Rows": 1, "Actual Loops": 8, "Output": ["partsupp_1.ps_supplycost", "supplier_1.s_nationkey"], "Inner Unique": false, "Hash Cond": "(supplier_1.s_suppkey = partsupp_1.ps_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier_1", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.002, "Actual Total Time": 0.057, "Actual Rows": 518, "Actual Loops": 8, "Output": ["supplier_1.s_suppkey", "supplier_1.s_name", "supplier_1.s_address", "supplier_1.s_nationkey", "supplier_1.s_phone", "supplier_1.s_acctbal", "supplier_1.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 20, "Actual Startup Time": 0.061, "Actual Total Time": 0.061, "Actual Rows": 1, "Actual Loops": 8, "Output": ["partsupp_1.ps_supplycost", "partsupp_1.ps_suppkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp_1", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 20, "Actual Startup Time": 0.041, "Actual Total Time": 0.06, "Actual Rows": 1, "Actual Loops": 8, "Output": ["partsupp_1.ps_supplycost", "partsupp_1.ps_suppkey"], "Filter": "(part.p_partkey = partsupp_1.ps_partkey)", "Rows Removed by Filter": 536}]}]}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region_1", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.001, "Actual Total Time": 0.001, "Actual Rows": 1, "Actual Loops": 8, "Output": ["region_1.r_regionkey", "region_1.r_name", "region_1.r_comment"], "Filter": "(region_1.r_name = 'EUROPE'::bpchar)", "Rows Removed by Filter": 4}]}]}]}]}]}, "Planning Time": 0.464, "Triggers": [], "Execution Time": 2.32}]
+[
+  {
+    "Plan": {
+      "Node Type": "Limit",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 86.97,
+      "Total Cost": 86.98,
+      "Plan Rows": 1,
+      "Plan Width": 714,
+      "Actual Startup Time": 0.802,
+      "Actual Total Time": 0.804,
+      "Actual Rows": 2,
+      "Actual Loops": 1,
+      "Output": [
+        "supplier.s_acctbal",
+        "supplier.s_name",
+        "nation.n_name",
+        "part.p_partkey",
+        "part.p_mfgr",
+        "supplier.s_address",
+        "supplier.s_phone",
+        "supplier.s_comment"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 86.97,
+          "Total Cost": 86.98,
+          "Plan Rows": 1,
+          "Plan Width": 714,
+          "Actual Startup Time": 0.801,
+          "Actual Total Time": 0.803,
+          "Actual Rows": 2,
+          "Actual Loops": 1,
+          "Output": [
+            "supplier.s_acctbal",
+            "supplier.s_name",
+            "nation.n_name",
+            "part.p_partkey",
+            "part.p_mfgr",
+            "supplier.s_address",
+            "supplier.s_phone",
+            "supplier.s_comment"
+          ],
+          "Sort Key": [
+            "supplier.s_acctbal DESC",
+            "nation.n_name",
+            "supplier.s_name",
+            "part.p_partkey"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 48.95,
+              "Total Cost": 86.96,
+              "Plan Rows": 1,
+              "Plan Width": 714,
+              "Actual Startup Time": 0.331,
+              "Actual Total Time": 0.8,
+              "Actual Rows": 2,
+              "Actual Loops": 1,
+              "Output": [
+                "supplier.s_acctbal",
+                "supplier.s_name",
+                "nation.n_name",
+                "part.p_partkey",
+                "part.p_mfgr",
+                "supplier.s_address",
+                "supplier.s_phone",
+                "supplier.s_comment"
+              ],
+              "Inner Unique": false,
+              "Hash Cond": "((part.p_partkey = partsupp.ps_partkey) AND ((SubPlan 1) = partsupp.ps_supplycost))",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "part",
+                  "Schema": "pg_temp",
+                  "Alias": "part",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.64,
+                  "Plan Rows": 1,
+                  "Plan Width": 108,
+                  "Actual Startup Time": 0.012,
+                  "Actual Total Time": 0.057,
+                  "Actual Rows": 6,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "part.p_partkey",
+                    "part.p_name",
+                    "part.p_mfgr",
+                    "part.p_brand",
+                    "part.p_type",
+                    "part.p_size",
+                    "part.p_container",
+                    "part.p_retailprice",
+                    "part.p_comment"
+                  ],
+                  "Filter": "(((part.p_type)::text ~~ '%BRASS'::text) AND (part.p_size = 15))",
+                  "Rows Removed by Filter": 527
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 48.93,
+                  "Total Cost": 48.93,
+                  "Plan Rows": 1,
+                  "Plan Width": 626,
+                  "Actual Startup Time": 0.159,
+                  "Actual Total Time": 0.16,
+                  "Actual Rows": 95,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "supplier.s_acctbal",
+                    "supplier.s_name",
+                    "supplier.s_address",
+                    "supplier.s_phone",
+                    "supplier.s_comment",
+                    "partsupp.ps_partkey",
+                    "partsupp.ps_supplycost",
+                    "nation.n_name"
+                  ],
+                  "Hash Buckets": 1024,
+                  "Original Hash Buckets": 1024,
+                  "Hash Batches": 1,
+                  "Original Hash Batches": 1,
+                  "Peak Memory Usage": 22,
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 36.58,
+                      "Total Cost": 48.93,
+                      "Plan Rows": 1,
+                      "Plan Width": 626,
+                      "Actual Startup Time": 0.086,
+                      "Actual Total Time": 0.141,
+                      "Actual Rows": 95,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "supplier.s_acctbal",
+                        "supplier.s_name",
+                        "supplier.s_address",
+                        "supplier.s_phone",
+                        "supplier.s_comment",
+                        "partsupp.ps_partkey",
+                        "partsupp.ps_supplycost",
+                        "nation.n_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(partsupp.ps_suppkey = supplier.s_suppkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "partsupp",
+                          "Schema": "pg_temp",
+                          "Alias": "partsupp",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.7,
+                          "Plan Rows": 170,
+                          "Plan Width": 24,
+                          "Actual Startup Time": 0.002,
+                          "Actual Total Time": 0.023,
+                          "Actual Rows": 537,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "partsupp.ps_partkey",
+                            "partsupp.ps_suppkey",
+                            "partsupp.ps_availqty",
+                            "partsupp.ps_supplycost",
+                            "partsupp.ps_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 36.57,
+                          "Total Cost": 36.57,
+                          "Plan Rows": 1,
+                          "Plan Width": 610,
+                          "Actual Startup Time": 0.082,
+                          "Actual Total Time": 0.082,
+                          "Actual Rows": 90,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "supplier.s_acctbal",
+                            "supplier.s_name",
+                            "supplier.s_address",
+                            "supplier.s_phone",
+                            "supplier.s_comment",
+                            "supplier.s_suppkey",
+                            "nation.n_name"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 21,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 24.5,
+                              "Total Cost": 36.57,
+                              "Plan Rows": 1,
+                              "Plan Width": 610,
+                              "Actual Startup Time": 0.016,
+                              "Actual Total Time": 0.068,
+                              "Actual Rows": 90,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "supplier.s_acctbal",
+                                "supplier.s_name",
+                                "supplier.s_address",
+                                "supplier.s_phone",
+                                "supplier.s_comment",
+                                "supplier.s_suppkey",
+                                "nation.n_name"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "supplier",
+                                  "Schema": "pg_temp",
+                                  "Alias": "supplier",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.5,
+                                  "Plan Rows": 150,
+                                  "Plan Width": 510,
+                                  "Actual Startup Time": 0.002,
+                                  "Actual Total Time": 0.023,
+                                  "Actual Rows": 518,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "supplier.s_suppkey",
+                                    "supplier.s_name",
+                                    "supplier.s_address",
+                                    "supplier.s_nationkey",
+                                    "supplier.s_phone",
+                                    "supplier.s_acctbal",
+                                    "supplier.s_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 24.48,
+                                  "Total Cost": 24.48,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 108,
+                                  "Actual Startup Time": 0.012,
+                                  "Actual Total Time": 0.012,
+                                  "Actual Rows": 5,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "nation.n_name",
+                                    "nation.n_nationkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 9,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Hash Join",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Join Type": "Inner",
+                                      "Startup Cost": 12.14,
+                                      "Total Cost": 24.48,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 108,
+                                      "Actual Startup Time": 0.009,
+                                      "Actual Total Time": 0.011,
+                                      "Actual Rows": 5,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "nation.n_name",
+                                        "nation.n_nationkey"
+                                      ],
+                                      "Inner Unique": false,
+                                      "Hash Cond": "(nation.n_regionkey = region.r_regionkey)",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "nation",
+                                          "Schema": "pg_temp",
+                                          "Alias": "nation",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 11.7,
+                                          "Plan Rows": 170,
+                                          "Plan Width": 112,
+                                          "Actual Startup Time": 0.001,
+                                          "Actual Total Time": 0.002,
+                                          "Actual Rows": 25,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "nation.n_nationkey",
+                                            "nation.n_name",
+                                            "nation.n_regionkey",
+                                            "nation.n_comment"
+                                          ]
+                                        },
+                                        {
+                                          "Node Type": "Hash",
+                                          "Parent Relationship": "Inner",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Startup Cost": 12.12,
+                                          "Total Cost": 12.12,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 4,
+                                          "Actual Startup Time": 0.003,
+                                          "Actual Total Time": 0.003,
+                                          "Actual Rows": 1,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "region.r_regionkey"
+                                          ],
+                                          "Hash Buckets": 1024,
+                                          "Original Hash Buckets": 1024,
+                                          "Hash Batches": 1,
+                                          "Original Hash Batches": 1,
+                                          "Peak Memory Usage": 9,
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Seq Scan",
+                                              "Parent Relationship": "Outer",
+                                              "Parallel Aware": false,
+                                              "Async Capable": false,
+                                              "Relation Name": "region",
+                                              "Schema": "pg_temp",
+                                              "Alias": "region",
+                                              "Startup Cost": 0.0,
+                                              "Total Cost": 12.12,
+                                              "Plan Rows": 1,
+                                              "Plan Width": 4,
+                                              "Actual Startup Time": 0.002,
+                                              "Actual Total Time": 0.002,
+                                              "Actual Rows": 1,
+                                              "Actual Loops": 1,
+                                              "Output": [
+                                                "region.r_regionkey"
+                                              ],
+                                              "Filter": "(region.r_name = 'EUROPE'::bpchar)",
+                                              "Rows Removed by Filter": 4
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Node Type": "Aggregate",
+                  "Strategy": "Plain",
+                  "Partial Mode": "Simple",
+                  "Parent Relationship": "SubPlan",
+                  "Subplan Name": "SubPlan 1",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 48.71,
+                  "Total Cost": 48.72,
+                  "Plan Rows": 1,
+                  "Plan Width": 32,
+                  "Actual Startup Time": 0.072,
+                  "Actual Total Time": 0.072,
+                  "Actual Rows": 1,
+                  "Actual Loops": 8,
+                  "Output": [
+                    "min(partsupp_1.ps_supplycost)"
+                  ],
+                  "Plans": [
+                    {
+                      "Node Type": "Nested Loop",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 24.22,
+                      "Total Cost": 48.71,
+                      "Plan Rows": 1,
+                      "Plan Width": 16,
+                      "Actual Startup Time": 0.071,
+                      "Actual Total Time": 0.072,
+                      "Actual Rows": 0,
+                      "Actual Loops": 8,
+                      "Output": [
+                        "partsupp_1.ps_supplycost"
+                      ],
+                      "Inner Unique": false,
+                      "Join Filter": "(nation_1.n_regionkey = region_1.r_regionkey)",
+                      "Rows Removed by Join Filter": 0,
+                      "Plans": [
+                        {
+                          "Node Type": "Hash Join",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Join Type": "Inner",
+                          "Startup Cost": 24.22,
+                          "Total Cost": 36.57,
+                          "Plan Rows": 1,
+                          "Plan Width": 20,
+                          "Actual Startup Time": 0.068,
+                          "Actual Total Time": 0.069,
+                          "Actual Rows": 1,
+                          "Actual Loops": 8,
+                          "Output": [
+                            "partsupp_1.ps_supplycost",
+                            "nation_1.n_regionkey"
+                          ],
+                          "Inner Unique": false,
+                          "Hash Cond": "(nation_1.n_nationkey = supplier_1.s_nationkey)",
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "nation",
+                              "Schema": "pg_temp",
+                              "Alias": "nation_1",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 11.7,
+                              "Plan Rows": 170,
+                              "Plan Width": 8,
+                              "Actual Startup Time": 0.0,
+                              "Actual Total Time": 0.001,
+                              "Actual Rows": 25,
+                              "Actual Loops": 8,
+                              "Output": [
+                                "nation_1.n_nationkey",
+                                "nation_1.n_name",
+                                "nation_1.n_regionkey",
+                                "nation_1.n_comment"
+                              ]
+                            },
+                            {
+                              "Node Type": "Hash",
+                              "Parent Relationship": "Inner",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 24.21,
+                              "Total Cost": 24.21,
+                              "Plan Rows": 1,
+                              "Plan Width": 20,
+                              "Actual Startup Time": 0.065,
+                              "Actual Total Time": 0.065,
+                              "Actual Rows": 1,
+                              "Actual Loops": 8,
+                              "Output": [
+                                "partsupp_1.ps_supplycost",
+                                "supplier_1.s_nationkey"
+                              ],
+                              "Hash Buckets": 1024,
+                              "Original Hash Buckets": 1024,
+                              "Hash Batches": 1,
+                              "Original Hash Batches": 1,
+                              "Peak Memory Usage": 9,
+                              "Plans": [
+                                {
+                                  "Node Type": "Hash Join",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Join Type": "Inner",
+                                  "Startup Cost": 12.14,
+                                  "Total Cost": 24.21,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 20,
+                                  "Actual Startup Time": 0.046,
+                                  "Actual Total Time": 0.064,
+                                  "Actual Rows": 1,
+                                  "Actual Loops": 8,
+                                  "Output": [
+                                    "partsupp_1.ps_supplycost",
+                                    "supplier_1.s_nationkey"
+                                  ],
+                                  "Inner Unique": false,
+                                  "Hash Cond": "(supplier_1.s_suppkey = partsupp_1.ps_suppkey)",
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "supplier",
+                                      "Schema": "pg_temp",
+                                      "Alias": "supplier_1",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 11.5,
+                                      "Plan Rows": 150,
+                                      "Plan Width": 8,
+                                      "Actual Startup Time": 0.001,
+                                      "Actual Total Time": 0.021,
+                                      "Actual Rows": 518,
+                                      "Actual Loops": 8,
+                                      "Output": [
+                                        "supplier_1.s_suppkey",
+                                        "supplier_1.s_name",
+                                        "supplier_1.s_address",
+                                        "supplier_1.s_nationkey",
+                                        "supplier_1.s_phone",
+                                        "supplier_1.s_acctbal",
+                                        "supplier_1.s_comment"
+                                      ]
+                                    },
+                                    {
+                                      "Node Type": "Hash",
+                                      "Parent Relationship": "Inner",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Startup Cost": 12.12,
+                                      "Total Cost": 12.12,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 20,
+                                      "Actual Startup Time": 0.021,
+                                      "Actual Total Time": 0.021,
+                                      "Actual Rows": 1,
+                                      "Actual Loops": 8,
+                                      "Output": [
+                                        "partsupp_1.ps_supplycost",
+                                        "partsupp_1.ps_suppkey"
+                                      ],
+                                      "Hash Buckets": 1024,
+                                      "Original Hash Buckets": 1024,
+                                      "Hash Batches": 1,
+                                      "Original Hash Batches": 1,
+                                      "Peak Memory Usage": 9,
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "partsupp",
+                                          "Schema": "pg_temp",
+                                          "Alias": "partsupp_1",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 12.12,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 20,
+                                          "Actual Startup Time": 0.013,
+                                          "Actual Total Time": 0.02,
+                                          "Actual Rows": 1,
+                                          "Actual Loops": 8,
+                                          "Output": [
+                                            "partsupp_1.ps_supplycost",
+                                            "partsupp_1.ps_suppkey"
+                                          ],
+                                          "Filter": "(part.p_partkey = partsupp_1.ps_partkey)",
+                                          "Rows Removed by Filter": 536
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "region",
+                          "Schema": "pg_temp",
+                          "Alias": "region_1",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.12,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.001,
+                          "Actual Total Time": 0.001,
+                          "Actual Rows": 1,
+                          "Actual Loops": 8,
+                          "Output": [
+                            "region_1.r_regionkey",
+                            "region_1.r_name",
+                            "region_1.r_comment"
+                          ],
+                          "Filter": "(region_1.r_name = 'EUROPE'::bpchar)",
+                          "Rows Removed by Filter": 4
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.147,
+    "Triggers": [],
+    "Execution Time": 0.828
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q2.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q2.plan.json
@@ -1,1 +1,507 @@
-[{"Plan": {"Node Type": "Limit", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 86.97, "Total Cost": 86.98, "Plan Rows": 1, "Plan Width": 714, "Output": ["supplier.s_acctbal", "supplier.s_name", "nation.n_name", "part.p_partkey", "part.p_mfgr", "supplier.s_address", "supplier.s_phone", "supplier.s_comment"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 86.97, "Total Cost": 86.98, "Plan Rows": 1, "Plan Width": 714, "Output": ["supplier.s_acctbal", "supplier.s_name", "nation.n_name", "part.p_partkey", "part.p_mfgr", "supplier.s_address", "supplier.s_phone", "supplier.s_comment"], "Sort Key": ["supplier.s_acctbal DESC", "nation.n_name", "supplier.s_name", "part.p_partkey"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 48.95, "Total Cost": 86.96, "Plan Rows": 1, "Plan Width": 714, "Output": ["supplier.s_acctbal", "supplier.s_name", "nation.n_name", "part.p_partkey", "part.p_mfgr", "supplier.s_address", "supplier.s_phone", "supplier.s_comment"], "Inner Unique": false, "Hash Cond": "((part.p_partkey = partsupp.ps_partkey) AND ((SubPlan 1) = partsupp.ps_supplycost))", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 13.64, "Plan Rows": 1, "Plan Width": 108, "Output": ["part.p_partkey", "part.p_name", "part.p_mfgr", "part.p_brand", "part.p_type", "part.p_size", "part.p_container", "part.p_retailprice", "part.p_comment"], "Filter": "(((part.p_type)::text ~~ '%BRASS'::text) AND (part.p_size = 15))"}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 48.93, "Total Cost": 48.93, "Plan Rows": 1, "Plan Width": 626, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "partsupp.ps_partkey", "partsupp.ps_supplycost", "nation.n_name"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 36.58, "Total Cost": 48.93, "Plan Rows": 1, "Plan Width": 626, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "partsupp.ps_partkey", "partsupp.ps_supplycost", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(partsupp.ps_suppkey = supplier.s_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 24, "Output": ["partsupp.ps_partkey", "partsupp.ps_suppkey", "partsupp.ps_availqty", "partsupp.ps_supplycost", "partsupp.ps_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 36.57, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 610, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "supplier.s_suppkey", "nation.n_name"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.5, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 610, "Output": ["supplier.s_acctbal", "supplier.s_name", "supplier.s_address", "supplier.s_phone", "supplier.s_comment", "supplier.s_suppkey", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 510, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.48, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 108, "Output": ["nation.n_name", "nation.n_nationkey"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 108, "Output": ["nation.n_name", "nation.n_nationkey"], "Inner Unique": false, "Hash Cond": "(nation.n_regionkey = region.r_regionkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 112, "Output": ["nation.n_nationkey", "nation.n_name", "nation.n_regionkey", "nation.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Output": ["region.r_regionkey"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Output": ["region.r_regionkey"], "Filter": "(region.r_name = 'EUROPE'::bpchar)"}]}]}]}]}]}]}]}, {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 48.71, "Total Cost": 48.72, "Plan Rows": 1, "Plan Width": 32, "Output": ["min(partsupp_1.ps_supplycost)"], "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.22, "Total Cost": 48.71, "Plan Rows": 1, "Plan Width": 16, "Output": ["partsupp_1.ps_supplycost"], "Inner Unique": false, "Join Filter": "(nation_1.n_regionkey = region_1.r_regionkey)", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.22, "Total Cost": 36.57, "Plan Rows": 1, "Plan Width": 20, "Output": ["partsupp_1.ps_supplycost", "nation_1.n_regionkey"], "Inner Unique": false, "Hash Cond": "(nation_1.n_nationkey = supplier_1.s_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation_1", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 8, "Output": ["nation_1.n_nationkey", "nation_1.n_name", "nation_1.n_regionkey", "nation_1.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.21, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 20, "Output": ["partsupp_1.ps_supplycost", "supplier_1.s_nationkey"], "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 20, "Output": ["partsupp_1.ps_supplycost", "supplier_1.s_nationkey"], "Inner Unique": false, "Hash Cond": "(supplier_1.s_suppkey = partsupp_1.ps_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier_1", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Output": ["supplier_1.s_suppkey", "supplier_1.s_name", "supplier_1.s_address", "supplier_1.s_nationkey", "supplier_1.s_phone", "supplier_1.s_acctbal", "supplier_1.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 20, "Output": ["partsupp_1.ps_supplycost", "partsupp_1.ps_suppkey"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp_1", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 20, "Output": ["partsupp_1.ps_supplycost", "partsupp_1.ps_suppkey"], "Filter": "(part.p_partkey = partsupp_1.ps_partkey)"}]}]}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region_1", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Output": ["region_1.r_regionkey", "region_1.r_name", "region_1.r_comment"], "Filter": "(region_1.r_name = 'EUROPE'::bpchar)"}]}]}]}]}]}}]
+[
+  {
+    "Plan": {
+      "Node Type": "Limit",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 86.97,
+      "Total Cost": 86.98,
+      "Plan Rows": 1,
+      "Plan Width": 714,
+      "Output": [
+        "supplier.s_acctbal",
+        "supplier.s_name",
+        "nation.n_name",
+        "part.p_partkey",
+        "part.p_mfgr",
+        "supplier.s_address",
+        "supplier.s_phone",
+        "supplier.s_comment"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 86.97,
+          "Total Cost": 86.98,
+          "Plan Rows": 1,
+          "Plan Width": 714,
+          "Output": [
+            "supplier.s_acctbal",
+            "supplier.s_name",
+            "nation.n_name",
+            "part.p_partkey",
+            "part.p_mfgr",
+            "supplier.s_address",
+            "supplier.s_phone",
+            "supplier.s_comment"
+          ],
+          "Sort Key": [
+            "supplier.s_acctbal DESC",
+            "nation.n_name",
+            "supplier.s_name",
+            "part.p_partkey"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 48.95,
+              "Total Cost": 86.96,
+              "Plan Rows": 1,
+              "Plan Width": 714,
+              "Output": [
+                "supplier.s_acctbal",
+                "supplier.s_name",
+                "nation.n_name",
+                "part.p_partkey",
+                "part.p_mfgr",
+                "supplier.s_address",
+                "supplier.s_phone",
+                "supplier.s_comment"
+              ],
+              "Inner Unique": false,
+              "Hash Cond": "((part.p_partkey = partsupp.ps_partkey) AND ((SubPlan 1) = partsupp.ps_supplycost))",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "part",
+                  "Schema": "pg_temp",
+                  "Alias": "part",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.64,
+                  "Plan Rows": 1,
+                  "Plan Width": 108,
+                  "Output": [
+                    "part.p_partkey",
+                    "part.p_name",
+                    "part.p_mfgr",
+                    "part.p_brand",
+                    "part.p_type",
+                    "part.p_size",
+                    "part.p_container",
+                    "part.p_retailprice",
+                    "part.p_comment"
+                  ],
+                  "Filter": "(((part.p_type)::text ~~ '%BRASS'::text) AND (part.p_size = 15))"
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 48.93,
+                  "Total Cost": 48.93,
+                  "Plan Rows": 1,
+                  "Plan Width": 626,
+                  "Output": [
+                    "supplier.s_acctbal",
+                    "supplier.s_name",
+                    "supplier.s_address",
+                    "supplier.s_phone",
+                    "supplier.s_comment",
+                    "partsupp.ps_partkey",
+                    "partsupp.ps_supplycost",
+                    "nation.n_name"
+                  ],
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 36.58,
+                      "Total Cost": 48.93,
+                      "Plan Rows": 1,
+                      "Plan Width": 626,
+                      "Output": [
+                        "supplier.s_acctbal",
+                        "supplier.s_name",
+                        "supplier.s_address",
+                        "supplier.s_phone",
+                        "supplier.s_comment",
+                        "partsupp.ps_partkey",
+                        "partsupp.ps_supplycost",
+                        "nation.n_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(partsupp.ps_suppkey = supplier.s_suppkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "partsupp",
+                          "Schema": "pg_temp",
+                          "Alias": "partsupp",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.7,
+                          "Plan Rows": 170,
+                          "Plan Width": 24,
+                          "Output": [
+                            "partsupp.ps_partkey",
+                            "partsupp.ps_suppkey",
+                            "partsupp.ps_availqty",
+                            "partsupp.ps_supplycost",
+                            "partsupp.ps_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 36.57,
+                          "Total Cost": 36.57,
+                          "Plan Rows": 1,
+                          "Plan Width": 610,
+                          "Output": [
+                            "supplier.s_acctbal",
+                            "supplier.s_name",
+                            "supplier.s_address",
+                            "supplier.s_phone",
+                            "supplier.s_comment",
+                            "supplier.s_suppkey",
+                            "nation.n_name"
+                          ],
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 24.5,
+                              "Total Cost": 36.57,
+                              "Plan Rows": 1,
+                              "Plan Width": 610,
+                              "Output": [
+                                "supplier.s_acctbal",
+                                "supplier.s_name",
+                                "supplier.s_address",
+                                "supplier.s_phone",
+                                "supplier.s_comment",
+                                "supplier.s_suppkey",
+                                "nation.n_name"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "supplier",
+                                  "Schema": "pg_temp",
+                                  "Alias": "supplier",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.5,
+                                  "Plan Rows": 150,
+                                  "Plan Width": 510,
+                                  "Output": [
+                                    "supplier.s_suppkey",
+                                    "supplier.s_name",
+                                    "supplier.s_address",
+                                    "supplier.s_nationkey",
+                                    "supplier.s_phone",
+                                    "supplier.s_acctbal",
+                                    "supplier.s_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 24.48,
+                                  "Total Cost": 24.48,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 108,
+                                  "Output": [
+                                    "nation.n_name",
+                                    "nation.n_nationkey"
+                                  ],
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Hash Join",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Join Type": "Inner",
+                                      "Startup Cost": 12.14,
+                                      "Total Cost": 24.48,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 108,
+                                      "Output": [
+                                        "nation.n_name",
+                                        "nation.n_nationkey"
+                                      ],
+                                      "Inner Unique": false,
+                                      "Hash Cond": "(nation.n_regionkey = region.r_regionkey)",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "nation",
+                                          "Schema": "pg_temp",
+                                          "Alias": "nation",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 11.7,
+                                          "Plan Rows": 170,
+                                          "Plan Width": 112,
+                                          "Output": [
+                                            "nation.n_nationkey",
+                                            "nation.n_name",
+                                            "nation.n_regionkey",
+                                            "nation.n_comment"
+                                          ]
+                                        },
+                                        {
+                                          "Node Type": "Hash",
+                                          "Parent Relationship": "Inner",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Startup Cost": 12.12,
+                                          "Total Cost": 12.12,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 4,
+                                          "Output": [
+                                            "region.r_regionkey"
+                                          ],
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Seq Scan",
+                                              "Parent Relationship": "Outer",
+                                              "Parallel Aware": false,
+                                              "Async Capable": false,
+                                              "Relation Name": "region",
+                                              "Schema": "pg_temp",
+                                              "Alias": "region",
+                                              "Startup Cost": 0.0,
+                                              "Total Cost": 12.12,
+                                              "Plan Rows": 1,
+                                              "Plan Width": 4,
+                                              "Output": [
+                                                "region.r_regionkey"
+                                              ],
+                                              "Filter": "(region.r_name = 'EUROPE'::bpchar)"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Node Type": "Aggregate",
+                  "Strategy": "Plain",
+                  "Partial Mode": "Simple",
+                  "Parent Relationship": "SubPlan",
+                  "Subplan Name": "SubPlan 1",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 48.71,
+                  "Total Cost": 48.72,
+                  "Plan Rows": 1,
+                  "Plan Width": 32,
+                  "Output": [
+                    "min(partsupp_1.ps_supplycost)"
+                  ],
+                  "Plans": [
+                    {
+                      "Node Type": "Nested Loop",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 24.22,
+                      "Total Cost": 48.71,
+                      "Plan Rows": 1,
+                      "Plan Width": 16,
+                      "Output": [
+                        "partsupp_1.ps_supplycost"
+                      ],
+                      "Inner Unique": false,
+                      "Join Filter": "(nation_1.n_regionkey = region_1.r_regionkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Hash Join",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Join Type": "Inner",
+                          "Startup Cost": 24.22,
+                          "Total Cost": 36.57,
+                          "Plan Rows": 1,
+                          "Plan Width": 20,
+                          "Output": [
+                            "partsupp_1.ps_supplycost",
+                            "nation_1.n_regionkey"
+                          ],
+                          "Inner Unique": false,
+                          "Hash Cond": "(nation_1.n_nationkey = supplier_1.s_nationkey)",
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "nation",
+                              "Schema": "pg_temp",
+                              "Alias": "nation_1",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 11.7,
+                              "Plan Rows": 170,
+                              "Plan Width": 8,
+                              "Output": [
+                                "nation_1.n_nationkey",
+                                "nation_1.n_name",
+                                "nation_1.n_regionkey",
+                                "nation_1.n_comment"
+                              ]
+                            },
+                            {
+                              "Node Type": "Hash",
+                              "Parent Relationship": "Inner",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 24.21,
+                              "Total Cost": 24.21,
+                              "Plan Rows": 1,
+                              "Plan Width": 20,
+                              "Output": [
+                                "partsupp_1.ps_supplycost",
+                                "supplier_1.s_nationkey"
+                              ],
+                              "Plans": [
+                                {
+                                  "Node Type": "Hash Join",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Join Type": "Inner",
+                                  "Startup Cost": 12.14,
+                                  "Total Cost": 24.21,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 20,
+                                  "Output": [
+                                    "partsupp_1.ps_supplycost",
+                                    "supplier_1.s_nationkey"
+                                  ],
+                                  "Inner Unique": false,
+                                  "Hash Cond": "(supplier_1.s_suppkey = partsupp_1.ps_suppkey)",
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "supplier",
+                                      "Schema": "pg_temp",
+                                      "Alias": "supplier_1",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 11.5,
+                                      "Plan Rows": 150,
+                                      "Plan Width": 8,
+                                      "Output": [
+                                        "supplier_1.s_suppkey",
+                                        "supplier_1.s_name",
+                                        "supplier_1.s_address",
+                                        "supplier_1.s_nationkey",
+                                        "supplier_1.s_phone",
+                                        "supplier_1.s_acctbal",
+                                        "supplier_1.s_comment"
+                                      ]
+                                    },
+                                    {
+                                      "Node Type": "Hash",
+                                      "Parent Relationship": "Inner",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Startup Cost": 12.12,
+                                      "Total Cost": 12.12,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 20,
+                                      "Output": [
+                                        "partsupp_1.ps_supplycost",
+                                        "partsupp_1.ps_suppkey"
+                                      ],
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "partsupp",
+                                          "Schema": "pg_temp",
+                                          "Alias": "partsupp_1",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 12.12,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 20,
+                                          "Output": [
+                                            "partsupp_1.ps_supplycost",
+                                            "partsupp_1.ps_suppkey"
+                                          ],
+                                          "Filter": "(part.p_partkey = partsupp_1.ps_partkey)"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "region",
+                          "Schema": "pg_temp",
+                          "Alias": "region_1",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.12,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Output": [
+                            "region_1.r_regionkey",
+                            "region_1.r_name",
+                            "region_1.r_comment"
+                          ],
+                          "Filter": "(region_1.r_name = 'EUROPE'::bpchar)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q20-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q20-analyze.plan.json
@@ -1,1 +1,302 @@
-[{"Plan": {"Node Type": "Sort", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 2435.48, "Total Cost": 2435.49, "Plan Rows": 1, "Plan Width": 202, "Actual Startup Time": 45.757, "Actual Total Time": 45.758, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name", "supplier.s_address"], "Sort Key": ["supplier.s_name"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 0.0, "Total Cost": 2435.47, "Plan Rows": 1, "Plan Width": 202, "Actual Startup Time": 45.702, "Actual Total Time": 45.753, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name", "supplier.s_address"], "Inner Unique": false, "Join Filter": "(supplier.s_nationkey = nation.n_nationkey)", "Rows Removed by Join Filter": 0, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Semi", "Startup Cost": 0.0, "Total Cost": 2423.33, "Plan Rows": 1, "Plan Width": 206, "Actual Startup Time": 45.7, "Actual Total Time": 45.749, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name", "supplier.s_address", "supplier.s_nationkey"], "Inner Unique": false, "Join Filter": "(supplier.s_suppkey = partsupp.ps_suppkey)", "Rows Removed by Join Filter": 517, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 210, "Actual Startup Time": 0.007, "Actual Total Time": 0.033, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Materialize", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 2409.59, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.063, "Actual Total Time": 0.088, "Actual Rows": 1, "Actual Loops": 518, "Output": ["partsupp.ps_suppkey"], "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Semi", "Startup Cost": 0.0, "Total Cost": 2409.58, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 32.467, "Actual Total Time": 45.632, "Actual Rows": 1, "Actual Loops": 1, "Output": ["partsupp.ps_suppkey"], "Inner Unique": false, "Join Filter": "(partsupp.ps_partkey = part.p_partkey)", "Rows Removed by Join Filter": 590, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 0.0, "Total Cost": 2395.52, "Plan Rows": 57, "Plan Width": 8, "Actual Startup Time": 0.582, "Actual Total Time": 45.396, "Actual Rows": 148, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_suppkey", "partsupp.ps_availqty", "partsupp.ps_supplycost", "partsupp.ps_comment"], "Filter": "((partsupp.ps_availqty)::numeric > (SubPlan 1))", "Rows Removed by Filter": 389, "Plans": [{"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "SubPlan", "Subplan Name": "SubPlan 1", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 14.0, "Total Cost": 14.02, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.084, "Actual Total Time": 0.084, "Actual Rows": 1, "Actual Loops": 537, "Output": ["(0.5 * sum(lineitem.l_quantity))"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 14.0, "Plan Rows": 1, "Plan Width": 16, "Actual Startup Time": 0.071, "Actual Total Time": 0.083, "Actual Rows": 0, "Actual Loops": 537, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "((lineitem.l_shipdate >= '1994-01-01'::date) AND (lineitem.l_shipdate < '1995-01-01'::date) AND (lineitem.l_partkey = partsupp.ps_partkey) AND (lineitem.l_suppkey = partsupp.ps_suppkey))", "Rows Removed by Filter": 572}]}]}, {"Node Type": "Materialize", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 0.0, "Total Cost": 13.21, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.0, "Actual Total Time": 0.001, "Actual Rows": 4, "Actual Loops": 148, "Output": ["part.p_partkey"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 13.2, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.01, "Actual Total Time": 0.127, "Actual Rows": 4, "Actual Loops": 1, "Output": ["part.p_partkey"], "Filter": "((part.p_name)::text ~~ 'forest%'::text)", "Rows Removed by Filter": 529}]}]}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.002, "Actual Total Time": 0.003, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_nationkey", "nation.n_name", "nation.n_regionkey", "nation.n_comment"], "Filter": "(nation.n_name = 'CANADA'::bpchar)", "Rows Removed by Filter": 24}]}]}, "Planning Time": 0.342, "Triggers": [], "Execution Time": 45.805}]
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 2435.48,
+      "Total Cost": 2435.49,
+      "Plan Rows": 1,
+      "Plan Width": 202,
+      "Actual Startup Time": 22.512,
+      "Actual Total Time": 22.513,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "supplier.s_name",
+        "supplier.s_address"
+      ],
+      "Sort Key": [
+        "supplier.s_name"
+      ],
+      "Sort Method": "quicksort",
+      "Sort Space Used": 25,
+      "Sort Space Type": "Memory",
+      "Plans": [
+        {
+          "Node Type": "Nested Loop",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Join Type": "Inner",
+          "Startup Cost": 0.0,
+          "Total Cost": 2435.47,
+          "Plan Rows": 1,
+          "Plan Width": 202,
+          "Actual Startup Time": 22.47,
+          "Actual Total Time": 22.511,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "supplier.s_name",
+            "supplier.s_address"
+          ],
+          "Inner Unique": false,
+          "Join Filter": "(supplier.s_nationkey = nation.n_nationkey)",
+          "Rows Removed by Join Filter": 0,
+          "Plans": [
+            {
+              "Node Type": "Nested Loop",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Semi",
+              "Startup Cost": 0.0,
+              "Total Cost": 2423.33,
+              "Plan Rows": 1,
+              "Plan Width": 206,
+              "Actual Startup Time": 22.467,
+              "Actual Total Time": 22.507,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "supplier.s_name",
+                "supplier.s_address",
+                "supplier.s_nationkey"
+              ],
+              "Inner Unique": false,
+              "Join Filter": "(supplier.s_suppkey = partsupp.ps_suppkey)",
+              "Rows Removed by Join Filter": 517,
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "supplier",
+                  "Schema": "pg_temp",
+                  "Alias": "supplier",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 11.5,
+                  "Plan Rows": 150,
+                  "Plan Width": 210,
+                  "Actual Startup Time": 0.003,
+                  "Actual Total Time": 0.021,
+                  "Actual Rows": 518,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "supplier.s_suppkey",
+                    "supplier.s_name",
+                    "supplier.s_address",
+                    "supplier.s_nationkey",
+                    "supplier.s_phone",
+                    "supplier.s_acctbal",
+                    "supplier.s_comment"
+                  ]
+                },
+                {
+                  "Node Type": "Materialize",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 0.0,
+                  "Total Cost": 2409.59,
+                  "Plan Rows": 1,
+                  "Plan Width": 4,
+                  "Actual Startup Time": 0.023,
+                  "Actual Total Time": 0.043,
+                  "Actual Rows": 1,
+                  "Actual Loops": 518,
+                  "Output": [
+                    "partsupp.ps_suppkey"
+                  ],
+                  "Plans": [
+                    {
+                      "Node Type": "Nested Loop",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Semi",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 2409.58,
+                      "Plan Rows": 1,
+                      "Plan Width": 4,
+                      "Actual Startup Time": 12.054,
+                      "Actual Total Time": 22.416,
+                      "Actual Rows": 1,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "partsupp.ps_suppkey"
+                      ],
+                      "Inner Unique": false,
+                      "Join Filter": "(partsupp.ps_partkey = part.p_partkey)",
+                      "Rows Removed by Join Filter": 590,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "partsupp",
+                          "Schema": "pg_temp",
+                          "Alias": "partsupp",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 2395.52,
+                          "Plan Rows": 57,
+                          "Plan Width": 8,
+                          "Actual Startup Time": 0.147,
+                          "Actual Total Time": 22.329,
+                          "Actual Rows": 148,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "partsupp.ps_partkey",
+                            "partsupp.ps_suppkey",
+                            "partsupp.ps_availqty",
+                            "partsupp.ps_supplycost",
+                            "partsupp.ps_comment"
+                          ],
+                          "Filter": "((partsupp.ps_availqty)::numeric > (SubPlan 1))",
+                          "Rows Removed by Filter": 389,
+                          "Plans": [
+                            {
+                              "Node Type": "Aggregate",
+                              "Strategy": "Plain",
+                              "Partial Mode": "Simple",
+                              "Parent Relationship": "SubPlan",
+                              "Subplan Name": "SubPlan 1",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Startup Cost": 14.0,
+                              "Total Cost": 14.02,
+                              "Plan Rows": 1,
+                              "Plan Width": 32,
+                              "Actual Startup Time": 0.041,
+                              "Actual Total Time": 0.041,
+                              "Actual Rows": 1,
+                              "Actual Loops": 537,
+                              "Output": [
+                                "(0.5 * sum(lineitem.l_quantity))"
+                              ],
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "lineitem",
+                                  "Schema": "pg_temp",
+                                  "Alias": "lineitem",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 14.0,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 16,
+                                  "Actual Startup Time": 0.035,
+                                  "Actual Total Time": 0.04,
+                                  "Actual Rows": 0,
+                                  "Actual Loops": 537,
+                                  "Output": [
+                                    "lineitem.l_orderkey",
+                                    "lineitem.l_partkey",
+                                    "lineitem.l_suppkey",
+                                    "lineitem.l_linenumber",
+                                    "lineitem.l_quantity",
+                                    "lineitem.l_extendedprice",
+                                    "lineitem.l_discount",
+                                    "lineitem.l_tax",
+                                    "lineitem.l_returnflag",
+                                    "lineitem.l_linestatus",
+                                    "lineitem.l_shipdate",
+                                    "lineitem.l_commitdate",
+                                    "lineitem.l_receiptdate",
+                                    "lineitem.l_shipinstruct",
+                                    "lineitem.l_shipmode",
+                                    "lineitem.l_comment"
+                                  ],
+                                  "Filter": "((lineitem.l_shipdate >= '1994-01-01'::date) AND (lineitem.l_shipdate < '1995-01-01'::date) AND (lineitem.l_partkey = partsupp.ps_partkey) AND (lineitem.l_suppkey = partsupp.ps_suppkey))",
+                                  "Rows Removed by Filter": 572
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Materialize",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 0.0,
+                          "Total Cost": 13.21,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.0,
+                          "Actual Total Time": 0.0,
+                          "Actual Rows": 4,
+                          "Actual Loops": 148,
+                          "Output": [
+                            "part.p_partkey"
+                          ],
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "part",
+                              "Schema": "pg_temp",
+                              "Alias": "part",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 13.2,
+                              "Plan Rows": 1,
+                              "Plan Width": 4,
+                              "Actual Startup Time": 0.004,
+                              "Actual Total Time": 0.029,
+                              "Actual Rows": 4,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "part.p_partkey"
+                              ],
+                              "Filter": "((part.p_name)::text ~~ 'forest%'::text)",
+                              "Rows Removed by Filter": 529
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "nation",
+              "Schema": "pg_temp",
+              "Alias": "nation",
+              "Startup Cost": 0.0,
+              "Total Cost": 12.12,
+              "Plan Rows": 1,
+              "Plan Width": 4,
+              "Actual Startup Time": 0.002,
+              "Actual Total Time": 0.004,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "nation.n_nationkey",
+                "nation.n_name",
+                "nation.n_regionkey",
+                "nation.n_comment"
+              ],
+              "Filter": "(nation.n_name = 'CANADA'::bpchar)",
+              "Rows Removed by Filter": 24
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.087,
+    "Triggers": [],
+    "Execution Time": 22.526
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q21-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q21-analyze.plan.json
@@ -1,1 +1,499 @@
-[{"Plan": {"Node Type": "Limit", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 78.73, "Total Cost": 78.73, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 4.104, "Actual Total Time": 4.105, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name", "(count(*))"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 78.73, "Total Cost": 78.73, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 4.103, "Actual Total Time": 4.104, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name", "(count(*))"], "Sort Key": ["(count(*)) DESC", "supplier.s_name"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 78.7, "Total Cost": 78.72, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 4.101, "Actual Total Time": 4.102, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name", "count(*)"], "Group Key": ["supplier.s_name"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 78.7, "Total Cost": 78.7, "Plan Rows": 1, "Plan Width": 104, "Actual Startup Time": 4.099, "Actual Total Time": 4.1, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name"], "Sort Key": ["supplier.s_name"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Anti", "Startup Cost": 12.14, "Total Cost": 78.69, "Plan Rows": 1, "Plan Width": 104, "Actual Startup Time": 2.086, "Actual Total Time": 4.098, "Actual Rows": 1, "Actual Loops": 1, "Output": ["supplier.s_name"], "Inner Unique": false, "Join Filter": "((l3.l_suppkey <> l1.l_suppkey) AND (l3.l_orderkey = l1.l_orderkey))", "Rows Removed by Join Filter": 3354, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Semi", "Startup Cost": 12.14, "Total Cost": 65.19, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 0.127, "Actual Total Time": 3.427, "Actual Rows": 15, "Actual Loops": 1, "Output": ["supplier.s_name", "l1.l_suppkey", "l1.l_orderkey"], "Inner Unique": false, "Join Filter": "((l2.l_suppkey <> l1.l_suppkey) AND (orders.o_orderkey = l2.l_orderkey))", "Rows Removed by Join Filter": 6840, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 50.19, "Plan Rows": 1, "Plan Width": 116, "Actual Startup Time": 0.118, "Actual Total Time": 2.773, "Actual Rows": 18, "Actual Loops": 1, "Output": ["supplier.s_name", "l1.l_suppkey", "l1.l_orderkey", "orders.o_orderkey"], "Inner Unique": false, "Join Filter": "(l1.l_orderkey = orders.o_orderkey)", "Rows Removed by Join Filter": 1953, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 37.55, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 0.084, "Actual Total Time": 2.431, "Actual Rows": 27, "Actual Loops": 1, "Output": ["supplier.s_name", "l1.l_suppkey", "l1.l_orderkey"], "Inner Unique": false, "Join Filter": "(supplier.s_suppkey = l1.l_suppkey)", "Rows Removed by Join Filter": 12188, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.21, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.015, "Actual Total Time": 0.07, "Actual Rows": 35, "Actual Loops": 1, "Output": ["supplier.s_name", "supplier.s_suppkey"], "Inner Unique": false, "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 112, "Actual Startup Time": 0.003, "Actual Total Time": 0.028, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.005, "Actual Total Time": 0.005, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.004, "Actual Total Time": 0.004, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_nationkey"], "Filter": "(nation.n_name = 'SAUDI ARABIA'::bpchar)", "Rows Removed by Filter": 24}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "l1", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.056, "Actual Rows": 349, "Actual Loops": 35, "Output": ["l1.l_orderkey", "l1.l_partkey", "l1.l_suppkey", "l1.l_linenumber", "l1.l_quantity", "l1.l_extendedprice", "l1.l_discount", "l1.l_tax", "l1.l_returnflag", "l1.l_linestatus", "l1.l_shipdate", "l1.l_commitdate", "l1.l_receiptdate", "l1.l_shipinstruct", "l1.l_shipmode", "l1.l_comment"], "Filter": "(l1.l_receiptdate > l1.l_commitdate)", "Rows Removed by Filter": 223}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.62, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.001, "Actual Total Time": 0.01, "Actual Rows": 73, "Actual Loops": 27, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"], "Filter": "(orders.o_orderstatus = 'F'::bpchar)", "Rows Removed by Filter": 55}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "l2", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.017, "Actual Rows": 381, "Actual Loops": 18, "Output": ["l2.l_orderkey", "l2.l_partkey", "l2.l_suppkey", "l2.l_linenumber", "l2.l_quantity", "l2.l_extendedprice", "l2.l_discount", "l2.l_tax", "l2.l_returnflag", "l2.l_linestatus", "l2.l_shipdate", "l2.l_commitdate", "l2.l_receiptdate", "l2.l_shipinstruct", "l2.l_shipmode", "l2.l_comment"]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "l3", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.036, "Actual Rows": 225, "Actual Loops": 15, "Output": ["l3.l_orderkey", "l3.l_partkey", "l3.l_suppkey", "l3.l_linenumber", "l3.l_quantity", "l3.l_extendedprice", "l3.l_discount", "l3.l_tax", "l3.l_returnflag", "l3.l_linestatus", "l3.l_shipdate", "l3.l_commitdate", "l3.l_receiptdate", "l3.l_shipinstruct", "l3.l_shipmode", "l3.l_comment"], "Filter": "(l3.l_receiptdate > l3.l_commitdate)", "Rows Removed by Filter": 147}]}]}]}]}]}, "Planning Time": 0.266, "Triggers": [], "Execution Time": 4.128}]
+[
+  {
+    "Plan": {
+      "Node Type": "Limit",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 77.45,
+      "Total Cost": 77.46,
+      "Plan Rows": 1,
+      "Plan Width": 112,
+      "Actual Startup Time": 0.737,
+      "Actual Total Time": 0.738,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "supplier.s_name",
+        "(count(*))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 77.45,
+          "Total Cost": 77.46,
+          "Plan Rows": 1,
+          "Plan Width": 112,
+          "Actual Startup Time": 0.736,
+          "Actual Total Time": 0.737,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "supplier.s_name",
+            "(count(*))"
+          ],
+          "Sort Key": [
+            "(count(*)) DESC",
+            "supplier.s_name"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Aggregate",
+              "Strategy": "Sorted",
+              "Partial Mode": "Simple",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 77.42,
+              "Total Cost": 77.44,
+              "Plan Rows": 1,
+              "Plan Width": 112,
+              "Actual Startup Time": 0.735,
+              "Actual Total Time": 0.736,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "supplier.s_name",
+                "count(*)"
+              ],
+              "Group Key": [
+                "supplier.s_name"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Sort",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 77.42,
+                  "Total Cost": 77.43,
+                  "Plan Rows": 1,
+                  "Plan Width": 104,
+                  "Actual Startup Time": 0.733,
+                  "Actual Total Time": 0.734,
+                  "Actual Rows": 1,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "supplier.s_name"
+                  ],
+                  "Sort Key": [
+                    "supplier.s_name"
+                  ],
+                  "Sort Method": "quicksort",
+                  "Sort Space Used": 25,
+                  "Sort Space Type": "Memory",
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 49.63,
+                      "Total Cost": 77.41,
+                      "Plan Rows": 1,
+                      "Plan Width": 104,
+                      "Actual Startup Time": 0.506,
+                      "Actual Total Time": 0.733,
+                      "Actual Rows": 1,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "supplier.s_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(l1.l_suppkey = supplier.s_suppkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Nested Loop",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Join Type": "Semi",
+                          "Startup Cost": 25.41,
+                          "Total Cost": 53.17,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.19,
+                          "Actual Total Time": 0.683,
+                          "Actual Rows": 11,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "l1.l_suppkey"
+                          ],
+                          "Inner Unique": false,
+                          "Join Filter": "((l2.l_suppkey <> l1.l_suppkey) AND (orders.o_orderkey = l2.l_orderkey))",
+                          "Rows Removed by Join Filter": 7399,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Right Anti",
+                              "Startup Cost": 25.41,
+                              "Total Cost": 38.17,
+                              "Plan Rows": 1,
+                              "Plan Width": 12,
+                              "Actual Startup Time": 0.177,
+                              "Actual Total Time": 0.182,
+                              "Actual Rows": 19,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "l1.l_suppkey",
+                                "l1.l_orderkey",
+                                "orders.o_orderkey"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(l3.l_orderkey = l1.l_orderkey)",
+                              "Join Filter": "(l3.l_suppkey <> l1.l_suppkey)",
+                              "Rows Removed by Join Filter": 180,
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "lineitem",
+                                  "Schema": "pg_temp",
+                                  "Alias": "l3",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 12.5,
+                                  "Plan Rows": 67,
+                                  "Plan Width": 8,
+                                  "Actual Startup Time": 0.002,
+                                  "Actual Total Time": 0.046,
+                                  "Actual Rows": 349,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "l3.l_orderkey",
+                                    "l3.l_partkey",
+                                    "l3.l_suppkey",
+                                    "l3.l_linenumber",
+                                    "l3.l_quantity",
+                                    "l3.l_extendedprice",
+                                    "l3.l_discount",
+                                    "l3.l_tax",
+                                    "l3.l_returnflag",
+                                    "l3.l_linestatus",
+                                    "l3.l_shipdate",
+                                    "l3.l_commitdate",
+                                    "l3.l_receiptdate",
+                                    "l3.l_shipinstruct",
+                                    "l3.l_shipmode",
+                                    "l3.l_comment"
+                                  ],
+                                  "Filter": "(l3.l_receiptdate > l3.l_commitdate)",
+                                  "Rows Removed by Filter": 223
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 25.4,
+                                  "Total Cost": 25.4,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 12,
+                                  "Actual Startup Time": 0.092,
+                                  "Actual Total Time": 0.092,
+                                  "Actual Rows": 180,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "l1.l_suppkey",
+                                    "l1.l_orderkey",
+                                    "orders.o_orderkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 16,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Hash Join",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Join Type": "Inner",
+                                      "Startup Cost": 12.64,
+                                      "Total Cost": 25.4,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 12,
+                                      "Actual Startup Time": 0.016,
+                                      "Actual Total Time": 0.083,
+                                      "Actual Rows": 180,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "l1.l_suppkey",
+                                        "l1.l_orderkey",
+                                        "orders.o_orderkey"
+                                      ],
+                                      "Inner Unique": false,
+                                      "Hash Cond": "(l1.l_orderkey = orders.o_orderkey)",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "lineitem",
+                                          "Schema": "pg_temp",
+                                          "Alias": "l1",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 12.5,
+                                          "Plan Rows": 67,
+                                          "Plan Width": 8,
+                                          "Actual Startup Time": 0.002,
+                                          "Actual Total Time": 0.046,
+                                          "Actual Rows": 349,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "l1.l_orderkey",
+                                            "l1.l_partkey",
+                                            "l1.l_suppkey",
+                                            "l1.l_linenumber",
+                                            "l1.l_quantity",
+                                            "l1.l_extendedprice",
+                                            "l1.l_discount",
+                                            "l1.l_tax",
+                                            "l1.l_returnflag",
+                                            "l1.l_linestatus",
+                                            "l1.l_shipdate",
+                                            "l1.l_commitdate",
+                                            "l1.l_receiptdate",
+                                            "l1.l_shipinstruct",
+                                            "l1.l_shipmode",
+                                            "l1.l_comment"
+                                          ],
+                                          "Filter": "(l1.l_receiptdate > l1.l_commitdate)",
+                                          "Rows Removed by Filter": 223
+                                        },
+                                        {
+                                          "Node Type": "Hash",
+                                          "Parent Relationship": "Inner",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Startup Cost": 12.62,
+                                          "Total Cost": 12.62,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 4,
+                                          "Actual Startup Time": 0.013,
+                                          "Actual Total Time": 0.013,
+                                          "Actual Rows": 73,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "orders.o_orderkey"
+                                          ],
+                                          "Hash Buckets": 1024,
+                                          "Original Hash Buckets": 1024,
+                                          "Hash Batches": 1,
+                                          "Original Hash Batches": 1,
+                                          "Peak Memory Usage": 11,
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Seq Scan",
+                                              "Parent Relationship": "Outer",
+                                              "Parallel Aware": false,
+                                              "Async Capable": false,
+                                              "Relation Name": "orders",
+                                              "Schema": "pg_temp",
+                                              "Alias": "orders",
+                                              "Startup Cost": 0.0,
+                                              "Total Cost": 12.62,
+                                              "Plan Rows": 1,
+                                              "Plan Width": 4,
+                                              "Actual Startup Time": 0.002,
+                                              "Actual Total Time": 0.009,
+                                              "Actual Rows": 73,
+                                              "Actual Loops": 1,
+                                              "Output": [
+                                                "orders.o_orderkey"
+                                              ],
+                                              "Filter": "(orders.o_orderstatus = 'F'::bpchar)",
+                                              "Rows Removed by Filter": 55
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Inner",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "lineitem",
+                              "Schema": "pg_temp",
+                              "Alias": "l2",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 12.0,
+                              "Plan Rows": 200,
+                              "Plan Width": 8,
+                              "Actual Startup Time": 0.001,
+                              "Actual Total Time": 0.013,
+                              "Actual Rows": 390,
+                              "Actual Loops": 19,
+                              "Output": [
+                                "l2.l_orderkey",
+                                "l2.l_partkey",
+                                "l2.l_suppkey",
+                                "l2.l_linenumber",
+                                "l2.l_quantity",
+                                "l2.l_extendedprice",
+                                "l2.l_discount",
+                                "l2.l_tax",
+                                "l2.l_returnflag",
+                                "l2.l_linestatus",
+                                "l2.l_shipdate",
+                                "l2.l_commitdate",
+                                "l2.l_receiptdate",
+                                "l2.l_shipinstruct",
+                                "l2.l_shipmode",
+                                "l2.l_comment"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 24.21,
+                          "Total Cost": 24.21,
+                          "Plan Rows": 1,
+                          "Plan Width": 108,
+                          "Actual Startup Time": 0.047,
+                          "Actual Total Time": 0.048,
+                          "Actual Rows": 35,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "supplier.s_name",
+                            "supplier.s_suppkey"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 11,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 12.14,
+                              "Total Cost": 24.21,
+                              "Plan Rows": 1,
+                              "Plan Width": 108,
+                              "Actual Startup Time": 0.01,
+                              "Actual Total Time": 0.045,
+                              "Actual Rows": 35,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "supplier.s_name",
+                                "supplier.s_suppkey"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(supplier.s_nationkey = nation.n_nationkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "supplier",
+                                  "Schema": "pg_temp",
+                                  "Alias": "supplier",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.5,
+                                  "Plan Rows": 150,
+                                  "Plan Width": 112,
+                                  "Actual Startup Time": 0.003,
+                                  "Actual Total Time": 0.02,
+                                  "Actual Rows": 518,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "supplier.s_suppkey",
+                                    "supplier.s_name",
+                                    "supplier.s_address",
+                                    "supplier.s_nationkey",
+                                    "supplier.s_phone",
+                                    "supplier.s_acctbal",
+                                    "supplier.s_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 12.12,
+                                  "Total Cost": 12.12,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 4,
+                                  "Actual Startup Time": 0.004,
+                                  "Actual Total Time": 0.004,
+                                  "Actual Rows": 1,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "nation.n_nationkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 9,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "nation",
+                                      "Schema": "pg_temp",
+                                      "Alias": "nation",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 12.12,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 4,
+                                      "Actual Startup Time": 0.003,
+                                      "Actual Total Time": 0.003,
+                                      "Actual Rows": 1,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "nation.n_nationkey"
+                                      ],
+                                      "Filter": "(nation.n_name = 'SAUDI ARABIA'::bpchar)",
+                                      "Rows Removed by Filter": 24
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.207,
+    "Triggers": [],
+    "Execution Time": 0.754
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q22-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q22-analyze.plan.json
@@ -1,1 +1,210 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 42.14, "Total Cost": 42.17, "Plan Rows": 1, "Plan Width": 72, "Actual Startup Time": 0.452, "Actual Total Time": 0.454, "Actual Rows": 1, "Actual Loops": 1, "Output": ["(SUBSTRING(customer.c_phone FROM 1 FOR 2))", "count(*)", "sum(customer.c_acctbal)"], "Group Key": ["(SUBSTRING(customer.c_phone FROM 1 FOR 2))"], "Plans": [{"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parent Relationship": "InitPlan", "Subplan Name": "InitPlan 1 (returns $0)", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.68, "Total Cost": 13.69, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.179, "Actual Total Time": 0.18, "Actual Rows": 1, "Actual Loops": 1, "Output": ["avg(customer_1.c_acctbal)"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer_1", "Startup Cost": 0.0, "Total Cost": 13.68, "Plan Rows": 2, "Plan Width": 16, "Actual Startup Time": 0.015, "Actual Total Time": 0.161, "Actual Rows": 37, "Actual Loops": 1, "Output": ["customer_1.c_custkey", "customer_1.c_name", "customer_1.c_address", "customer_1.c_nationkey", "customer_1.c_phone", "customer_1.c_acctbal", "customer_1.c_mktsegment", "customer_1.c_comment"], "Filter": "((customer_1.c_acctbal > 0.00) AND (SUBSTRING(customer_1.c_phone FROM 1 FOR 2) = ANY ('{13,31,23,29,30,18,17}'::text[])))", "Rows Removed by Filter": 92}]}, {"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 28.45, "Total Cost": 28.45, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.444, "Actual Total Time": 0.445, "Actual Rows": 1, "Actual Loops": 1, "Output": ["(SUBSTRING(customer.c_phone FROM 1 FOR 2))", "customer.c_acctbal"], "Sort Key": ["(SUBSTRING(customer.c_phone FROM 1 FOR 2))"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Anti", "Startup Cost": 14.72, "Total Cost": 28.44, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.361, "Actual Total Time": 0.417, "Actual Rows": 1, "Actual Loops": 1, "Output": ["SUBSTRING(customer.c_phone FROM 1 FOR 2)", "customer.c_acctbal"], "Inner Unique": false, "Hash Cond": "(customer.c_custkey = orders.o_custkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 13.68, "Plan Rows": 2, "Plan Width": 84, "Actual Startup Time": 0.195, "Actual Total Time": 0.291, "Actual Rows": 20, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_address", "customer.c_nationkey", "customer.c_phone", "customer.c_acctbal", "customer.c_mktsegment", "customer.c_comment"], "Filter": "((customer.c_acctbal > $0) AND (SUBSTRING(customer.c_phone FROM 1 FOR 2) = ANY ('{13,31,23,29,30,18,17}'::text[])))", "Rows Removed by Filter": 109}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.1, "Total Cost": 12.1, "Plan Rows": 210, "Plan Width": 4, "Actual Startup Time": 0.109, "Actual Total Time": 0.109, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_custkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 13, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.1, "Plan Rows": 210, "Plan Width": 4, "Actual Startup Time": 0.006, "Actual Total Time": 0.033, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_custkey"]}]}]}]}]}, "Planning Time": 0.454, "Triggers": [], "Execution Time": 0.513}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 40.32,
+      "Total Cost": 40.35,
+      "Plan Rows": 1,
+      "Plan Width": 72,
+      "Actual Startup Time": 0.081,
+      "Actual Total Time": 0.081,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "(SUBSTRING(customer.c_phone FROM 1 FOR 2))",
+        "count(*)",
+        "sum(customer.c_acctbal)"
+      ],
+      "Group Key": [
+        "(SUBSTRING(customer.c_phone FROM 1 FOR 2))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Plain",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "InitPlan",
+          "Subplan Name": "InitPlan 1",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 13.68,
+          "Total Cost": 13.69,
+          "Plan Rows": 1,
+          "Plan Width": 32,
+          "Actual Startup Time": 0.039,
+          "Actual Total Time": 0.039,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "avg(customer_1.c_acctbal)"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "customer",
+              "Schema": "pg_temp",
+              "Alias": "customer_1",
+              "Startup Cost": 0.0,
+              "Total Cost": 13.68,
+              "Plan Rows": 2,
+              "Plan Width": 16,
+              "Actual Startup Time": 0.004,
+              "Actual Total Time": 0.035,
+              "Actual Rows": 37,
+              "Actual Loops": 1,
+              "Output": [
+                "customer_1.c_custkey",
+                "customer_1.c_name",
+                "customer_1.c_address",
+                "customer_1.c_nationkey",
+                "customer_1.c_phone",
+                "customer_1.c_acctbal",
+                "customer_1.c_mktsegment",
+                "customer_1.c_comment"
+              ],
+              "Filter": "((customer_1.c_acctbal > 0.00) AND (SUBSTRING(customer_1.c_phone FROM 1 FOR 2) = ANY ('{13,31,23,29,30,18,17}'::text[])))",
+              "Rows Removed by Filter": 92
+            }
+          ]
+        },
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 26.62,
+          "Total Cost": 26.63,
+          "Plan Rows": 1,
+          "Plan Width": 48,
+          "Actual Startup Time": 0.08,
+          "Actual Total Time": 0.08,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "(SUBSTRING(customer.c_phone FROM 1 FOR 2))",
+            "customer.c_acctbal"
+          ],
+          "Sort Key": [
+            "(SUBSTRING(customer.c_phone FROM 1 FOR 2))"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Right Anti",
+              "Startup Cost": 13.7,
+              "Total Cost": 26.61,
+              "Plan Rows": 1,
+              "Plan Width": 48,
+              "Actual Startup Time": 0.077,
+              "Actual Total Time": 0.079,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "SUBSTRING(customer.c_phone FROM 1 FOR 2)",
+                "customer.c_acctbal"
+              ],
+              "Inner Unique": false,
+              "Hash Cond": "(orders.o_custkey = customer.c_custkey)",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "orders",
+                  "Schema": "pg_temp",
+                  "Alias": "orders",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 12.1,
+                  "Plan Rows": 210,
+                  "Plan Width": 4,
+                  "Actual Startup Time": 0.001,
+                  "Actual Total Time": 0.005,
+                  "Actual Rows": 128,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "orders.o_orderkey",
+                    "orders.o_custkey",
+                    "orders.o_orderstatus",
+                    "orders.o_totalprice",
+                    "orders.o_orderdate",
+                    "orders.o_orderpriority",
+                    "orders.o_clerk",
+                    "orders.o_shippriority",
+                    "orders.o_comment"
+                  ]
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 13.68,
+                  "Total Cost": 13.68,
+                  "Plan Rows": 2,
+                  "Plan Width": 84,
+                  "Actual Startup Time": 0.064,
+                  "Actual Total Time": 0.064,
+                  "Actual Rows": 20,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "customer.c_phone",
+                    "customer.c_acctbal",
+                    "customer.c_custkey"
+                  ],
+                  "Hash Buckets": 1024,
+                  "Original Hash Buckets": 1024,
+                  "Hash Batches": 1,
+                  "Original Hash Batches": 1,
+                  "Peak Memory Usage": 10,
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "customer",
+                      "Schema": "pg_temp",
+                      "Alias": "customer",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 13.68,
+                      "Plan Rows": 2,
+                      "Plan Width": 84,
+                      "Actual Startup Time": 0.043,
+                      "Actual Total Time": 0.062,
+                      "Actual Rows": 20,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "customer.c_phone",
+                        "customer.c_acctbal",
+                        "customer.c_custkey"
+                      ],
+                      "Filter": "((customer.c_acctbal > (InitPlan 1).col1) AND (SUBSTRING(customer.c_phone FROM 1 FOR 2) = ANY ('{13,31,23,29,30,18,17}'::text[])))",
+                      "Rows Removed by Filter": 109
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.055,
+    "Triggers": [],
+    "Execution Time": 0.091
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q3-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q3-analyze.plan.json
@@ -1,1 +1,306 @@
-[{"Plan": {"Node Type": "Limit", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 37.49, "Total Cost": 37.49, "Plan Rows": 1, "Plan Width": 44, "Actual Startup Time": 0.171, "Actual Total Time": 0.173, "Actual Rows": 3, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))", "orders.o_orderdate", "orders.o_shippriority"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 37.49, "Total Cost": 37.49, "Plan Rows": 1, "Plan Width": 44, "Actual Startup Time": 0.171, "Actual Total Time": 0.172, "Actual Rows": 3, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))", "orders.o_orderdate", "orders.o_shippriority"], "Sort Key": ["(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))) DESC", "orders.o_orderdate"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 37.44, "Total Cost": 37.48, "Plan Rows": 1, "Plan Width": 44, "Actual Startup Time": 0.161, "Actual Total Time": 0.168, "Actual Rows": 3, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))", "orders.o_orderdate", "orders.o_shippriority"], "Group Key": ["lineitem.l_orderkey", "orders.o_orderdate", "orders.o_shippriority"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 37.44, "Total Cost": 37.45, "Plan Rows": 1, "Plan Width": 44, "Actual Startup Time": 0.154, "Actual Total Time": 0.156, "Actual Rows": 11, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "orders.o_orderdate", "orders.o_shippriority", "lineitem.l_extendedprice", "lineitem.l_discount"], "Sort Key": ["lineitem.l_orderkey", "orders.o_orderdate", "orders.o_shippriority"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.67, "Total Cost": 37.43, "Plan Rows": 1, "Plan Width": 44, "Actual Startup Time": 0.081, "Actual Total Time": 0.148, "Actual Rows": 11, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "orders.o_orderdate", "orders.o_shippriority", "lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Hash Cond": "(lineitem.l_orderkey = orders.o_orderkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 36, "Actual Startup Time": 0.007, "Actual Total Time": 0.076, "Actual Rows": 282, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "(lineitem.l_shipdate > '1995-03-15'::date)", "Rows Removed by Filter": 290}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.66, "Total Cost": 24.66, "Plan Rows": 1, "Plan Width": 12, "Actual Startup Time": 0.051, "Actual Total Time": 0.052, "Actual Rows": 15, "Actual Loops": 1, "Output": ["orders.o_orderdate", "orders.o_shippriority", "orders.o_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 11.76, "Total Cost": 24.66, "Plan Rows": 1, "Plan Width": 12, "Actual Startup Time": 0.032, "Actual Total Time": 0.049, "Actual Rows": 15, "Actual Loops": 1, "Output": ["orders.o_orderdate", "orders.o_shippriority", "orders.o_orderkey"], "Inner Unique": false, "Hash Cond": "(orders.o_custkey = customer.c_custkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.62, "Plan Rows": 70, "Plan Width": 16, "Actual Startup Time": 0.003, "Actual Total Time": 0.015, "Actual Rows": 75, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"], "Filter": "(orders.o_orderdate < '1995-03-15'::date)", "Rows Removed by Filter": 53}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 11.75, "Total Cost": 11.75, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.023, "Actual Total Time": 0.023, "Actual Rows": 29, "Actual Loops": 1, "Output": ["customer.c_custkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 10, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.75, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.003, "Actual Total Time": 0.018, "Actual Rows": 29, "Actual Loops": 1, "Output": ["customer.c_custkey"], "Filter": "(customer.c_mktsegment = 'BUILDING'::bpchar)", "Rows Removed by Filter": 100}]}]}]}]}]}]}]}]}, "Planning Time": 0.105, "Triggers": [], "Execution Time": 0.198}]
+[
+  {
+    "Plan": {
+      "Node Type": "Limit",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 37.49,
+      "Total Cost": 37.49,
+      "Plan Rows": 1,
+      "Plan Width": 44,
+      "Actual Startup Time": 0.086,
+      "Actual Total Time": 0.087,
+      "Actual Rows": 3,
+      "Actual Loops": 1,
+      "Output": [
+        "lineitem.l_orderkey",
+        "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))",
+        "orders.o_orderdate",
+        "orders.o_shippriority"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 37.49,
+          "Total Cost": 37.49,
+          "Plan Rows": 1,
+          "Plan Width": 44,
+          "Actual Startup Time": 0.086,
+          "Actual Total Time": 0.087,
+          "Actual Rows": 3,
+          "Actual Loops": 1,
+          "Output": [
+            "lineitem.l_orderkey",
+            "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))",
+            "orders.o_orderdate",
+            "orders.o_shippriority"
+          ],
+          "Sort Key": [
+            "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))) DESC",
+            "orders.o_orderdate"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Aggregate",
+              "Strategy": "Sorted",
+              "Partial Mode": "Simple",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 37.44,
+              "Total Cost": 37.48,
+              "Plan Rows": 1,
+              "Plan Width": 44,
+              "Actual Startup Time": 0.081,
+              "Actual Total Time": 0.085,
+              "Actual Rows": 3,
+              "Actual Loops": 1,
+              "Output": [
+                "lineitem.l_orderkey",
+                "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))",
+                "orders.o_orderdate",
+                "orders.o_shippriority"
+              ],
+              "Group Key": [
+                "lineitem.l_orderkey",
+                "orders.o_orderdate",
+                "orders.o_shippriority"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Sort",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 37.44,
+                  "Total Cost": 37.45,
+                  "Plan Rows": 1,
+                  "Plan Width": 44,
+                  "Actual Startup Time": 0.078,
+                  "Actual Total Time": 0.079,
+                  "Actual Rows": 11,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "lineitem.l_orderkey",
+                    "orders.o_orderdate",
+                    "orders.o_shippriority",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount"
+                  ],
+                  "Sort Key": [
+                    "lineitem.l_orderkey",
+                    "orders.o_orderdate",
+                    "orders.o_shippriority"
+                  ],
+                  "Sort Method": "quicksort",
+                  "Sort Space Used": 25,
+                  "Sort Space Type": "Memory",
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 24.67,
+                      "Total Cost": 37.43,
+                      "Plan Rows": 1,
+                      "Plan Width": 44,
+                      "Actual Startup Time": 0.04,
+                      "Actual Total Time": 0.076,
+                      "Actual Rows": 11,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "lineitem.l_orderkey",
+                        "orders.o_orderdate",
+                        "orders.o_shippriority",
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(lineitem.l_orderkey = orders.o_orderkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "lineitem",
+                          "Schema": "pg_temp",
+                          "Alias": "lineitem",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.5,
+                          "Plan Rows": 67,
+                          "Plan Width": 36,
+                          "Actual Startup Time": 0.003,
+                          "Actual Total Time": 0.04,
+                          "Actual Rows": 282,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "lineitem.l_orderkey",
+                            "lineitem.l_partkey",
+                            "lineitem.l_suppkey",
+                            "lineitem.l_linenumber",
+                            "lineitem.l_quantity",
+                            "lineitem.l_extendedprice",
+                            "lineitem.l_discount",
+                            "lineitem.l_tax",
+                            "lineitem.l_returnflag",
+                            "lineitem.l_linestatus",
+                            "lineitem.l_shipdate",
+                            "lineitem.l_commitdate",
+                            "lineitem.l_receiptdate",
+                            "lineitem.l_shipinstruct",
+                            "lineitem.l_shipmode",
+                            "lineitem.l_comment"
+                          ],
+                          "Filter": "(lineitem.l_shipdate > '1995-03-15'::date)",
+                          "Rows Removed by Filter": 290
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 24.66,
+                          "Total Cost": 24.66,
+                          "Plan Rows": 1,
+                          "Plan Width": 12,
+                          "Actual Startup Time": 0.025,
+                          "Actual Total Time": 0.025,
+                          "Actual Rows": 15,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "orders.o_orderdate",
+                            "orders.o_shippriority",
+                            "orders.o_orderkey"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 9,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 11.76,
+                              "Total Cost": 24.66,
+                              "Plan Rows": 1,
+                              "Plan Width": 12,
+                              "Actual Startup Time": 0.016,
+                              "Actual Total Time": 0.024,
+                              "Actual Rows": 15,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "orders.o_orderdate",
+                                "orders.o_shippriority",
+                                "orders.o_orderkey"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(orders.o_custkey = customer.c_custkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "orders",
+                                  "Schema": "pg_temp",
+                                  "Alias": "orders",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 12.62,
+                                  "Plan Rows": 70,
+                                  "Plan Width": 16,
+                                  "Actual Startup Time": 0.001,
+                                  "Actual Total Time": 0.007,
+                                  "Actual Rows": 75,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "orders.o_orderkey",
+                                    "orders.o_custkey",
+                                    "orders.o_orderstatus",
+                                    "orders.o_totalprice",
+                                    "orders.o_orderdate",
+                                    "orders.o_orderpriority",
+                                    "orders.o_clerk",
+                                    "orders.o_shippriority",
+                                    "orders.o_comment"
+                                  ],
+                                  "Filter": "(orders.o_orderdate < '1995-03-15'::date)",
+                                  "Rows Removed by Filter": 53
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 11.75,
+                                  "Total Cost": 11.75,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 4,
+                                  "Actual Startup Time": 0.011,
+                                  "Actual Total Time": 0.011,
+                                  "Actual Rows": 29,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "customer.c_custkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 10,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "customer",
+                                      "Schema": "pg_temp",
+                                      "Alias": "customer",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 11.75,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 4,
+                                      "Actual Startup Time": 0.002,
+                                      "Actual Total Time": 0.009,
+                                      "Actual Rows": 29,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "customer.c_custkey"
+                                      ],
+                                      "Filter": "(customer.c_mktsegment = 'BUILDING'::bpchar)",
+                                      "Rows Removed by Filter": 100
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.044,
+    "Triggers": [],
+    "Execution Time": 0.097
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q4-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q4-analyze.plan.json
@@ -1,1 +1,146 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 26.5, "Total Cost": 26.52, "Plan Rows": 1, "Plan Width": 72, "Actual Startup Time": 0.306, "Actual Total Time": 0.308, "Actual Rows": 4, "Actual Loops": 1, "Output": ["orders.o_orderpriority", "count(*)"], "Group Key": ["orders.o_orderpriority"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 26.5, "Total Cost": 26.5, "Plan Rows": 1, "Plan Width": 64, "Actual Startup Time": 0.303, "Actual Total Time": 0.304, "Actual Rows": 5, "Actual Loops": 1, "Output": ["orders.o_orderpriority"], "Sort Key": ["orders.o_orderpriority"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Semi", "Startup Cost": 0.0, "Total Cost": 26.49, "Plan Rows": 1, "Plan Width": 64, "Actual Startup Time": 0.029, "Actual Total Time": 0.297, "Actual Rows": 5, "Actual Loops": 1, "Output": ["orders.o_orderpriority"], "Inner Unique": false, "Join Filter": "(orders.o_orderkey = lineitem.l_orderkey)", "Rows Removed by Join Filter": 1002, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 13.15, "Plan Rows": 1, "Plan Width": 68, "Actual Startup Time": 0.008, "Actual Total Time": 0.017, "Actual Rows": 5, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"], "Filter": "((orders.o_orderdate >= '1993-07-01'::date) AND (orders.o_orderdate < '1993-10-01'::date))", "Rows Removed by Filter": 123}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.5, "Plan Rows": 67, "Plan Width": 4, "Actual Startup Time": 0.002, "Actual Total Time": 0.047, "Actual Rows": 201, "Actual Loops": 5, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "(lineitem.l_commitdate < lineitem.l_receiptdate)", "Rows Removed by Filter": 133}]}]}]}, "Planning Time": 0.071, "Triggers": [], "Execution Time": 0.324}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 26.5,
+      "Total Cost": 26.52,
+      "Plan Rows": 1,
+      "Plan Width": 72,
+      "Actual Startup Time": 0.175,
+      "Actual Total Time": 0.176,
+      "Actual Rows": 4,
+      "Actual Loops": 1,
+      "Output": [
+        "orders.o_orderpriority",
+        "count(*)"
+      ],
+      "Group Key": [
+        "orders.o_orderpriority"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 26.5,
+          "Total Cost": 26.5,
+          "Plan Rows": 1,
+          "Plan Width": 64,
+          "Actual Startup Time": 0.174,
+          "Actual Total Time": 0.174,
+          "Actual Rows": 5,
+          "Actual Loops": 1,
+          "Output": [
+            "orders.o_orderpriority"
+          ],
+          "Sort Key": [
+            "orders.o_orderpriority"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Nested Loop",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Semi",
+              "Startup Cost": 0.0,
+              "Total Cost": 26.49,
+              "Plan Rows": 1,
+              "Plan Width": 64,
+              "Actual Startup Time": 0.015,
+              "Actual Total Time": 0.167,
+              "Actual Rows": 5,
+              "Actual Loops": 1,
+              "Output": [
+                "orders.o_orderpriority"
+              ],
+              "Inner Unique": false,
+              "Join Filter": "(orders.o_orderkey = lineitem.l_orderkey)",
+              "Rows Removed by Join Filter": 1002,
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "orders",
+                  "Schema": "pg_temp",
+                  "Alias": "orders",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.15,
+                  "Plan Rows": 1,
+                  "Plan Width": 68,
+                  "Actual Startup Time": 0.003,
+                  "Actual Total Time": 0.008,
+                  "Actual Rows": 5,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "orders.o_orderkey",
+                    "orders.o_custkey",
+                    "orders.o_orderstatus",
+                    "orders.o_totalprice",
+                    "orders.o_orderdate",
+                    "orders.o_orderpriority",
+                    "orders.o_clerk",
+                    "orders.o_shippriority",
+                    "orders.o_comment"
+                  ],
+                  "Filter": "((orders.o_orderdate >= '1993-07-01'::date) AND (orders.o_orderdate < '1993-10-01'::date))",
+                  "Rows Removed by Filter": 123
+                },
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "lineitem",
+                  "Schema": "pg_temp",
+                  "Alias": "lineitem",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 12.5,
+                  "Plan Rows": 67,
+                  "Plan Width": 4,
+                  "Actual Startup Time": 0.001,
+                  "Actual Total Time": 0.026,
+                  "Actual Rows": 201,
+                  "Actual Loops": 5,
+                  "Output": [
+                    "lineitem.l_orderkey",
+                    "lineitem.l_partkey",
+                    "lineitem.l_suppkey",
+                    "lineitem.l_linenumber",
+                    "lineitem.l_quantity",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount",
+                    "lineitem.l_tax",
+                    "lineitem.l_returnflag",
+                    "lineitem.l_linestatus",
+                    "lineitem.l_shipdate",
+                    "lineitem.l_commitdate",
+                    "lineitem.l_receiptdate",
+                    "lineitem.l_shipinstruct",
+                    "lineitem.l_shipmode",
+                    "lineitem.l_comment"
+                  ],
+                  "Filter": "(lineitem.l_commitdate < lineitem.l_receiptdate)",
+                  "Rows Removed by Filter": 133
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.026,
+    "Triggers": [],
+    "Execution Time": 0.182
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q5-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q5-analyze.plan.json
@@ -1,1 +1,472 @@
-[{"Plan": {"Node Type": "Sort", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 74.5, "Total Cost": 74.51, "Plan Rows": 1, "Plan Width": 136, "Actual Startup Time": 5.384, "Actual Total Time": 5.385, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_name", "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))"], "Sort Key": ["(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))) DESC"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 74.47, "Total Cost": 74.49, "Plan Rows": 1, "Plan Width": 136, "Actual Startup Time": 5.374, "Actual Total Time": 5.376, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_name", "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"], "Group Key": ["nation.n_name"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 74.47, "Total Cost": 74.47, "Plan Rows": 1, "Plan Width": 136, "Actual Startup Time": 5.37, "Actual Total Time": 5.371, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_name", "lineitem.l_extendedprice", "lineitem.l_discount"], "Sort Key": ["nation.n_name"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 48.53, "Total Cost": 74.45, "Plan Rows": 1, "Plan Width": 136, "Actual Startup Time": 2.706, "Actual Total Time": 5.368, "Actual Rows": 1, "Actual Loops": 1, "Output": ["nation.n_name", "lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Join Filter": "((customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey))", "Rows Removed by Join Filter": 18251, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 48.53, "Total Cost": 61.29, "Plan Rows": 1, "Plan Width": 144, "Actual Startup Time": 0.194, "Actual Total Time": 0.306, "Actual Rows": 468, "Actual Loops": 1, "Output": ["customer.c_custkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_orderkey", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(lineitem.l_suppkey = supplier.s_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 40, "Actual Startup Time": 0.005, "Actual Total Time": 0.033, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 48.52, "Total Cost": 48.52, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 0.185, "Actual Total Time": 0.186, "Actual Rows": 460, "Actual Loops": 1, "Output": ["customer.c_custkey", "supplier.s_suppkey", "nation.n_name"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 38, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 36.45, "Total Cost": 48.52, "Plan Rows": 1, "Plan Width": 112, "Actual Startup Time": 0.038, "Actual Total Time": 0.139, "Actual Rows": 460, "Actual Loops": 1, "Output": ["customer.c_custkey", "supplier.s_suppkey", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(supplier.s_nationkey = customer.c_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.002, "Actual Total Time": 0.028, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 36.43, "Total Cost": 36.43, "Plan Rows": 1, "Plan Width": 116, "Actual Startup Time": 0.035, "Actual Total Time": 0.035, "Actual Rows": 21, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_nationkey", "nation.n_name", "nation.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 10, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.5, "Total Cost": 36.43, "Plan Rows": 1, "Plan Width": 116, "Actual Startup Time": 0.016, "Actual Total Time": 0.033, "Actual Rows": 21, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_nationkey", "nation.n_name", "nation.n_nationkey"], "Inner Unique": false, "Hash Cond": "(customer.c_nationkey = nation.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 8, "Actual Startup Time": 0.002, "Actual Total Time": 0.008, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_address", "customer.c_nationkey", "customer.c_phone", "customer.c_acctbal", "customer.c_mktsegment", "customer.c_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.48, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.012, "Actual Total Time": 0.013, "Actual Rows": 5, "Actual Loops": 1, "Output": ["nation.n_name", "nation.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 108, "Actual Startup Time": 0.009, "Actual Total Time": 0.012, "Actual Rows": 5, "Actual Loops": 1, "Output": ["nation.n_name", "nation.n_nationkey"], "Inner Unique": false, "Hash Cond": "(nation.n_regionkey = region.r_regionkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 112, "Actual Startup Time": 0.001, "Actual Total Time": 0.002, "Actual Rows": 25, "Actual Loops": 1, "Output": ["nation.n_nationkey", "nation.n_name", "nation.n_regionkey", "nation.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.004, "Actual Total Time": 0.005, "Actual Rows": 1, "Actual Loops": 1, "Output": ["region.r_regionkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.002, "Actual Total Time": 0.003, "Actual Rows": 1, "Actual Loops": 1, "Output": ["region.r_regionkey"], "Filter": "(region.r_name = 'ASIA'::bpchar)", "Rows Removed by Filter": 4}]}]}]}]}]}]}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 13.15, "Plan Rows": 1, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.009, "Actual Rows": 39, "Actual Loops": 468, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"], "Filter": "((orders.o_orderdate >= '1994-01-01'::date) AND (orders.o_orderdate < '1995-01-01'::date))", "Rows Removed by Filter": 89}]}]}]}]}, "Planning Time": 0.292, "Triggers": [], "Execution Time": 5.414}]
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 74.5,
+      "Total Cost": 74.51,
+      "Plan Rows": 1,
+      "Plan Width": 136,
+      "Actual Startup Time": 3.918,
+      "Actual Total Time": 3.919,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "nation.n_name",
+        "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))"
+      ],
+      "Sort Key": [
+        "(sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))) DESC"
+      ],
+      "Sort Method": "quicksort",
+      "Sort Space Used": 25,
+      "Sort Space Type": "Memory",
+      "Plans": [
+        {
+          "Node Type": "Aggregate",
+          "Strategy": "Sorted",
+          "Partial Mode": "Simple",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 74.47,
+          "Total Cost": 74.49,
+          "Plan Rows": 1,
+          "Plan Width": 136,
+          "Actual Startup Time": 3.916,
+          "Actual Total Time": 3.918,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "nation.n_name",
+            "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"
+          ],
+          "Group Key": [
+            "nation.n_name"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Sort",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 74.47,
+              "Total Cost": 74.47,
+              "Plan Rows": 1,
+              "Plan Width": 136,
+              "Actual Startup Time": 3.912,
+              "Actual Total Time": 3.914,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "nation.n_name",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount"
+              ],
+              "Sort Key": [
+                "nation.n_name"
+              ],
+              "Sort Method": "quicksort",
+              "Sort Space Used": 25,
+              "Sort Space Type": "Memory",
+              "Plans": [
+                {
+                  "Node Type": "Nested Loop",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 48.53,
+                  "Total Cost": 74.45,
+                  "Plan Rows": 1,
+                  "Plan Width": 136,
+                  "Actual Startup Time": 1.942,
+                  "Actual Total Time": 3.912,
+                  "Actual Rows": 1,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "nation.n_name",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount"
+                  ],
+                  "Inner Unique": false,
+                  "Join Filter": "((customer.c_custkey = orders.o_custkey) AND (orders.o_orderkey = lineitem.l_orderkey))",
+                  "Rows Removed by Join Filter": 18251,
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 48.53,
+                      "Total Cost": 61.29,
+                      "Plan Rows": 1,
+                      "Plan Width": 144,
+                      "Actual Startup Time": 0.119,
+                      "Actual Total Time": 0.227,
+                      "Actual Rows": 468,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "customer.c_custkey",
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount",
+                        "lineitem.l_orderkey",
+                        "nation.n_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(lineitem.l_suppkey = supplier.s_suppkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "lineitem",
+                          "Schema": "pg_temp",
+                          "Alias": "lineitem",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.0,
+                          "Plan Rows": 200,
+                          "Plan Width": 40,
+                          "Actual Startup Time": 0.002,
+                          "Actual Total Time": 0.023,
+                          "Actual Rows": 572,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "lineitem.l_orderkey",
+                            "lineitem.l_partkey",
+                            "lineitem.l_suppkey",
+                            "lineitem.l_linenumber",
+                            "lineitem.l_quantity",
+                            "lineitem.l_extendedprice",
+                            "lineitem.l_discount",
+                            "lineitem.l_tax",
+                            "lineitem.l_returnflag",
+                            "lineitem.l_linestatus",
+                            "lineitem.l_shipdate",
+                            "lineitem.l_commitdate",
+                            "lineitem.l_receiptdate",
+                            "lineitem.l_shipinstruct",
+                            "lineitem.l_shipmode",
+                            "lineitem.l_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 48.52,
+                          "Total Cost": 48.52,
+                          "Plan Rows": 1,
+                          "Plan Width": 112,
+                          "Actual Startup Time": 0.115,
+                          "Actual Total Time": 0.116,
+                          "Actual Rows": 460,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "customer.c_custkey",
+                            "supplier.s_suppkey",
+                            "nation.n_name"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 38,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 36.45,
+                              "Total Cost": 48.52,
+                              "Plan Rows": 1,
+                              "Plan Width": 112,
+                              "Actual Startup Time": 0.023,
+                              "Actual Total Time": 0.086,
+                              "Actual Rows": 460,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "customer.c_custkey",
+                                "supplier.s_suppkey",
+                                "nation.n_name"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(supplier.s_nationkey = customer.c_nationkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "supplier",
+                                  "Schema": "pg_temp",
+                                  "Alias": "supplier",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.5,
+                                  "Plan Rows": 150,
+                                  "Plan Width": 8,
+                                  "Actual Startup Time": 0.001,
+                                  "Actual Total Time": 0.019,
+                                  "Actual Rows": 518,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "supplier.s_suppkey",
+                                    "supplier.s_name",
+                                    "supplier.s_address",
+                                    "supplier.s_nationkey",
+                                    "supplier.s_phone",
+                                    "supplier.s_acctbal",
+                                    "supplier.s_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 36.43,
+                                  "Total Cost": 36.43,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 116,
+                                  "Actual Startup Time": 0.021,
+                                  "Actual Total Time": 0.021,
+                                  "Actual Rows": 21,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "customer.c_custkey",
+                                    "customer.c_nationkey",
+                                    "nation.n_name",
+                                    "nation.n_nationkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 10,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Hash Join",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Join Type": "Inner",
+                                      "Startup Cost": 24.5,
+                                      "Total Cost": 36.43,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 116,
+                                      "Actual Startup Time": 0.009,
+                                      "Actual Total Time": 0.02,
+                                      "Actual Rows": 21,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "customer.c_custkey",
+                                        "customer.c_nationkey",
+                                        "nation.n_name",
+                                        "nation.n_nationkey"
+                                      ],
+                                      "Inner Unique": false,
+                                      "Hash Cond": "(customer.c_nationkey = nation.n_nationkey)",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "customer",
+                                          "Schema": "pg_temp",
+                                          "Alias": "customer",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 11.4,
+                                          "Plan Rows": 140,
+                                          "Plan Width": 8,
+                                          "Actual Startup Time": 0.001,
+                                          "Actual Total Time": 0.005,
+                                          "Actual Rows": 129,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "customer.c_custkey",
+                                            "customer.c_name",
+                                            "customer.c_address",
+                                            "customer.c_nationkey",
+                                            "customer.c_phone",
+                                            "customer.c_acctbal",
+                                            "customer.c_mktsegment",
+                                            "customer.c_comment"
+                                          ]
+                                        },
+                                        {
+                                          "Node Type": "Hash",
+                                          "Parent Relationship": "Inner",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Startup Cost": 24.48,
+                                          "Total Cost": 24.48,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 108,
+                                          "Actual Startup Time": 0.007,
+                                          "Actual Total Time": 0.007,
+                                          "Actual Rows": 5,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "nation.n_name",
+                                            "nation.n_nationkey"
+                                          ],
+                                          "Hash Buckets": 1024,
+                                          "Original Hash Buckets": 1024,
+                                          "Hash Batches": 1,
+                                          "Original Hash Batches": 1,
+                                          "Peak Memory Usage": 9,
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Hash Join",
+                                              "Parent Relationship": "Outer",
+                                              "Parallel Aware": false,
+                                              "Async Capable": false,
+                                              "Join Type": "Inner",
+                                              "Startup Cost": 12.14,
+                                              "Total Cost": 24.48,
+                                              "Plan Rows": 1,
+                                              "Plan Width": 108,
+                                              "Actual Startup Time": 0.005,
+                                              "Actual Total Time": 0.007,
+                                              "Actual Rows": 5,
+                                              "Actual Loops": 1,
+                                              "Output": [
+                                                "nation.n_name",
+                                                "nation.n_nationkey"
+                                              ],
+                                              "Inner Unique": false,
+                                              "Hash Cond": "(nation.n_regionkey = region.r_regionkey)",
+                                              "Plans": [
+                                                {
+                                                  "Node Type": "Seq Scan",
+                                                  "Parent Relationship": "Outer",
+                                                  "Parallel Aware": false,
+                                                  "Async Capable": false,
+                                                  "Relation Name": "nation",
+                                                  "Schema": "pg_temp",
+                                                  "Alias": "nation",
+                                                  "Startup Cost": 0.0,
+                                                  "Total Cost": 11.7,
+                                                  "Plan Rows": 170,
+                                                  "Plan Width": 112,
+                                                  "Actual Startup Time": 0.001,
+                                                  "Actual Total Time": 0.002,
+                                                  "Actual Rows": 25,
+                                                  "Actual Loops": 1,
+                                                  "Output": [
+                                                    "nation.n_nationkey",
+                                                    "nation.n_name",
+                                                    "nation.n_regionkey",
+                                                    "nation.n_comment"
+                                                  ]
+                                                },
+                                                {
+                                                  "Node Type": "Hash",
+                                                  "Parent Relationship": "Inner",
+                                                  "Parallel Aware": false,
+                                                  "Async Capable": false,
+                                                  "Startup Cost": 12.12,
+                                                  "Total Cost": 12.12,
+                                                  "Plan Rows": 1,
+                                                  "Plan Width": 4,
+                                                  "Actual Startup Time": 0.003,
+                                                  "Actual Total Time": 0.003,
+                                                  "Actual Rows": 1,
+                                                  "Actual Loops": 1,
+                                                  "Output": [
+                                                    "region.r_regionkey"
+                                                  ],
+                                                  "Hash Buckets": 1024,
+                                                  "Original Hash Buckets": 1024,
+                                                  "Hash Batches": 1,
+                                                  "Original Hash Batches": 1,
+                                                  "Peak Memory Usage": 9,
+                                                  "Plans": [
+                                                    {
+                                                      "Node Type": "Seq Scan",
+                                                      "Parent Relationship": "Outer",
+                                                      "Parallel Aware": false,
+                                                      "Async Capable": false,
+                                                      "Relation Name": "region",
+                                                      "Schema": "pg_temp",
+                                                      "Alias": "region",
+                                                      "Startup Cost": 0.0,
+                                                      "Total Cost": 12.12,
+                                                      "Plan Rows": 1,
+                                                      "Plan Width": 4,
+                                                      "Actual Startup Time": 0.002,
+                                                      "Actual Total Time": 0.002,
+                                                      "Actual Rows": 1,
+                                                      "Actual Loops": 1,
+                                                      "Output": [
+                                                        "region.r_regionkey"
+                                                      ],
+                                                      "Filter": "(region.r_name = 'ASIA'::bpchar)",
+                                                      "Rows Removed by Filter": 4
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "orders",
+                      "Schema": "pg_temp",
+                      "Alias": "orders",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 13.15,
+                      "Plan Rows": 1,
+                      "Plan Width": 8,
+                      "Actual Startup Time": 0.001,
+                      "Actual Total Time": 0.006,
+                      "Actual Rows": 39,
+                      "Actual Loops": 468,
+                      "Output": [
+                        "orders.o_orderkey",
+                        "orders.o_custkey",
+                        "orders.o_orderstatus",
+                        "orders.o_totalprice",
+                        "orders.o_orderdate",
+                        "orders.o_orderpriority",
+                        "orders.o_clerk",
+                        "orders.o_shippriority",
+                        "orders.o_comment"
+                      ],
+                      "Filter": "((orders.o_orderdate >= '1994-01-01'::date) AND (orders.o_orderdate < '1995-01-01'::date))",
+                      "Rows Removed by Filter": 89
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.176,
+    "Triggers": [],
+    "Execution Time": 3.934
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q6-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q6-analyze.plan.json
@@ -1,1 +1,64 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Plain", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 14.51, "Total Cost": 14.52, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.252, "Actual Total Time": 0.253, "Actual Rows": 1, "Actual Loops": 1, "Output": ["sum((l_extendedprice * l_discount))"], "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 14.5, "Plan Rows": 1, "Plan Width": 32, "Actual Startup Time": 0.042, "Actual Total Time": 0.232, "Actual Rows": 20, "Actual Loops": 1, "Output": ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment"], "Filter": "((lineitem.l_shipdate >= '1994-01-01'::date) AND (lineitem.l_shipdate < '1995-01-01'::date) AND (lineitem.l_discount >= 0.05) AND (lineitem.l_discount <= 0.07) AND (lineitem.l_quantity < '24'::numeric))", "Rows Removed by Filter": 552}]}, "Planning Time": 0.088, "Triggers": [], "Execution Time": 0.28}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Plain",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 14.51,
+      "Total Cost": 14.52,
+      "Plan Rows": 1,
+      "Plan Width": 32,
+      "Actual Startup Time": 0.05,
+      "Actual Total Time": 0.05,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "sum((l_extendedprice * l_discount))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Relation Name": "lineitem",
+          "Schema": "pg_temp",
+          "Alias": "lineitem",
+          "Startup Cost": 0.0,
+          "Total Cost": 14.5,
+          "Plan Rows": 1,
+          "Plan Width": 32,
+          "Actual Startup Time": 0.01,
+          "Actual Total Time": 0.046,
+          "Actual Rows": 20,
+          "Actual Loops": 1,
+          "Output": [
+            "l_orderkey",
+            "l_partkey",
+            "l_suppkey",
+            "l_linenumber",
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax",
+            "l_returnflag",
+            "l_linestatus",
+            "l_shipdate",
+            "l_commitdate",
+            "l_receiptdate",
+            "l_shipinstruct",
+            "l_shipmode",
+            "l_comment"
+          ],
+          "Filter": "((lineitem.l_shipdate >= '1994-01-01'::date) AND (lineitem.l_shipdate < '1995-01-01'::date) AND (lineitem.l_discount >= 0.05) AND (lineitem.l_discount <= 0.07) AND (lineitem.l_quantity < '24'::numeric))",
+          "Rows Removed by Filter": 552
+        }
+      ]
+    },
+    "Planning Time": 0.022,
+    "Triggers": [],
+    "Execution Time": 0.055
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q7-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q7-analyze.plan.json
@@ -1,1 +1,428 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 75.19, "Total Cost": 75.23, "Plan Rows": 1, "Plan Width": 272, "Actual Startup Time": 11.121, "Actual Total Time": 11.123, "Actual Rows": 1, "Actual Loops": 1, "Output": ["n1.n_name", "n2.n_name", "(EXTRACT(year FROM lineitem.l_shipdate))", "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"], "Group Key": ["n1.n_name", "n2.n_name", "(EXTRACT(year FROM lineitem.l_shipdate))"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 75.19, "Total Cost": 75.2, "Plan Rows": 1, "Plan Width": 272, "Actual Startup Time": 11.116, "Actual Total Time": 11.118, "Actual Rows": 1, "Actual Loops": 1, "Output": ["n1.n_name", "n2.n_name", "(EXTRACT(year FROM lineitem.l_shipdate))", "lineitem.l_extendedprice", "lineitem.l_discount"], "Sort Key": ["n1.n_name", "n2.n_name", "(EXTRACT(year FROM lineitem.l_shipdate))"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 37.12, "Total Cost": 75.18, "Plan Rows": 1, "Plan Width": 272, "Actual Startup Time": 1.786, "Actual Total Time": 11.112, "Actual Rows": 1, "Actual Loops": 1, "Output": ["n1.n_name", "n2.n_name", "EXTRACT(year FROM lineitem.l_shipdate)", "lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Join Filter": "((supplier.s_suppkey = lineitem.l_suppkey) AND (((n1.n_name = 'FRANCE'::bpchar) AND (n2.n_name = 'GERMANY'::bpchar)) OR ((n1.n_name = 'GERMANY'::bpchar) AND (n2.n_name = 'FRANCE'::bpchar))))", "Rows Removed by Join Filter": 1319, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.55, "Total Cost": 50.48, "Plan Rows": 1, "Plan Width": 144, "Actual Startup Time": 0.157, "Actual Total Time": 7.344, "Actual Rows": 30, "Actual Loops": 1, "Output": ["lineitem.l_shipdate", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_suppkey", "n2.n_name"], "Inner Unique": false, "Join Filter": "(orders.o_orderkey = lineitem.l_orderkey)", "Rows Removed by Join Filter": 2862, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 13.0, "Plan Rows": 1, "Plan Width": 44, "Actual Startup Time": 0.01, "Actual Total Time": 0.124, "Actual Rows": 241, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"], "Filter": "((lineitem.l_shipdate >= '1995-01-01'::date) AND (lineitem.l_shipdate <= '1996-12-31'::date))", "Rows Removed by Filter": 331}, {"Node Type": "Hash Join", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 24.55, "Total Cost": 37.45, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.004, "Actual Total Time": 0.029, "Actual Rows": 12, "Actual Loops": 241, "Output": ["orders.o_orderkey", "n2.n_name"], "Inner Unique": false, "Hash Cond": "(orders.o_custkey = customer.c_custkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.1, "Plan Rows": 210, "Plan Width": 8, "Actual Startup Time": 0.002, "Actual Total Time": 0.013, "Actual Rows": 128, "Actual Loops": 241, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 24.52, "Total Cost": 24.52, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.06, "Actual Total Time": 0.061, "Actual Rows": 12, "Actual Loops": 1, "Output": ["customer.c_custkey", "n2.n_name"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.58, "Total Cost": 24.52, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.027, "Actual Total Time": 0.057, "Actual Rows": 12, "Actual Loops": 1, "Output": ["customer.c_custkey", "n2.n_name"], "Inner Unique": false, "Hash Cond": "(customer.c_nationkey = n2.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 8, "Actual Startup Time": 0.003, "Actual Total Time": 0.015, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_address", "customer.c_nationkey", "customer.c_phone", "customer.c_acctbal", "customer.c_mktsegment", "customer.c_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.55, "Total Cost": 12.55, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.012, "Actual Total Time": 0.013, "Actual Rows": 2, "Actual Loops": 1, "Output": ["n2.n_name", "n2.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "n2", "Startup Cost": 0.0, "Total Cost": 12.55, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.005, "Actual Total Time": 0.009, "Actual Rows": 2, "Actual Loops": 1, "Output": ["n2.n_name", "n2.n_nationkey"], "Filter": "((n2.n_name = 'GERMANY'::bpchar) OR (n2.n_name = 'FRANCE'::bpchar))", "Rows Removed by Filter": 23}]}]}]}]}]}, {"Node Type": "Hash Join", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.58, "Total Cost": 24.66, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.007, "Actual Total Time": 0.122, "Actual Rows": 44, "Actual Loops": 30, "Output": ["supplier.s_suppkey", "n1.n_name"], "Inner Unique": false, "Hash Cond": "(supplier.s_nationkey = n1.n_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.002, "Actual Total Time": 0.051, "Actual Rows": 518, "Actual Loops": 30, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.55, "Total Cost": 12.55, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.009, "Actual Total Time": 0.009, "Actual Rows": 2, "Actual Loops": 1, "Output": ["n1.n_name", "n1.n_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "n1", "Startup Cost": 0.0, "Total Cost": 12.55, "Plan Rows": 2, "Plan Width": 108, "Actual Startup Time": 0.004, "Actual Total Time": 0.008, "Actual Rows": 2, "Actual Loops": 1, "Output": ["n1.n_name", "n1.n_nationkey"], "Filter": "((n1.n_name = 'FRANCE'::bpchar) OR (n1.n_name = 'GERMANY'::bpchar))", "Rows Removed by Filter": 23}]}]}]}]}]}, "Planning Time": 0.498, "Triggers": [], "Execution Time": 11.17}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 75.19,
+      "Total Cost": 75.23,
+      "Plan Rows": 1,
+      "Plan Width": 272,
+      "Actual Startup Time": 4.088,
+      "Actual Total Time": 4.089,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "n1.n_name",
+        "n2.n_name",
+        "(EXTRACT(year FROM lineitem.l_shipdate))",
+        "sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)))"
+      ],
+      "Group Key": [
+        "n1.n_name",
+        "n2.n_name",
+        "(EXTRACT(year FROM lineitem.l_shipdate))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 75.19,
+          "Total Cost": 75.2,
+          "Plan Rows": 1,
+          "Plan Width": 272,
+          "Actual Startup Time": 4.084,
+          "Actual Total Time": 4.085,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "n1.n_name",
+            "n2.n_name",
+            "(EXTRACT(year FROM lineitem.l_shipdate))",
+            "lineitem.l_extendedprice",
+            "lineitem.l_discount"
+          ],
+          "Sort Key": [
+            "n1.n_name",
+            "n2.n_name",
+            "(EXTRACT(year FROM lineitem.l_shipdate))"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Nested Loop",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 37.12,
+              "Total Cost": 75.18,
+              "Plan Rows": 1,
+              "Plan Width": 272,
+              "Actual Startup Time": 0.574,
+              "Actual Total Time": 4.083,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "n1.n_name",
+                "n2.n_name",
+                "EXTRACT(year FROM lineitem.l_shipdate)",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount"
+              ],
+              "Inner Unique": false,
+              "Join Filter": "((supplier.s_suppkey = lineitem.l_suppkey) AND (((n1.n_name = 'FRANCE'::bpchar) AND (n2.n_name = 'GERMANY'::bpchar)) OR ((n1.n_name = 'GERMANY'::bpchar) AND (n2.n_name = 'FRANCE'::bpchar))))",
+              "Rows Removed by Join Filter": 1319,
+              "Plans": [
+                {
+                  "Node Type": "Nested Loop",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 24.55,
+                  "Total Cost": 50.48,
+                  "Plan Rows": 1,
+                  "Plan Width": 144,
+                  "Actual Startup Time": 0.047,
+                  "Actual Total Time": 2.831,
+                  "Actual Rows": 30,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "lineitem.l_shipdate",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount",
+                    "lineitem.l_suppkey",
+                    "n2.n_name"
+                  ],
+                  "Inner Unique": false,
+                  "Join Filter": "(lineitem.l_orderkey = orders.o_orderkey)",
+                  "Rows Removed by Join Filter": 2862,
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "lineitem",
+                      "Schema": "pg_temp",
+                      "Alias": "lineitem",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 13.0,
+                      "Plan Rows": 1,
+                      "Plan Width": 44,
+                      "Actual Startup Time": 0.003,
+                      "Actual Total Time": 0.054,
+                      "Actual Rows": 241,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "lineitem.l_orderkey",
+                        "lineitem.l_partkey",
+                        "lineitem.l_suppkey",
+                        "lineitem.l_linenumber",
+                        "lineitem.l_quantity",
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount",
+                        "lineitem.l_tax",
+                        "lineitem.l_returnflag",
+                        "lineitem.l_linestatus",
+                        "lineitem.l_shipdate",
+                        "lineitem.l_commitdate",
+                        "lineitem.l_receiptdate",
+                        "lineitem.l_shipinstruct",
+                        "lineitem.l_shipmode",
+                        "lineitem.l_comment"
+                      ],
+                      "Filter": "((lineitem.l_shipdate >= '1995-01-01'::date) AND (lineitem.l_shipdate <= '1996-12-31'::date))",
+                      "Rows Removed by Filter": 331
+                    },
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 24.55,
+                      "Total Cost": 37.45,
+                      "Plan Rows": 2,
+                      "Plan Width": 108,
+                      "Actual Startup Time": 0.001,
+                      "Actual Total Time": 0.011,
+                      "Actual Rows": 12,
+                      "Actual Loops": 241,
+                      "Output": [
+                        "orders.o_orderkey",
+                        "n2.n_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(orders.o_custkey = customer.c_custkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "orders",
+                          "Schema": "pg_temp",
+                          "Alias": "orders",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.1,
+                          "Plan Rows": 210,
+                          "Plan Width": 8,
+                          "Actual Startup Time": 0.001,
+                          "Actual Total Time": 0.005,
+                          "Actual Rows": 128,
+                          "Actual Loops": 241,
+                          "Output": [
+                            "orders.o_orderkey",
+                            "orders.o_custkey",
+                            "orders.o_orderstatus",
+                            "orders.o_totalprice",
+                            "orders.o_orderdate",
+                            "orders.o_orderpriority",
+                            "orders.o_clerk",
+                            "orders.o_shippriority",
+                            "orders.o_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 24.52,
+                          "Total Cost": 24.52,
+                          "Plan Rows": 2,
+                          "Plan Width": 108,
+                          "Actual Startup Time": 0.017,
+                          "Actual Total Time": 0.018,
+                          "Actual Rows": 12,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "customer.c_custkey",
+                            "n2.n_name"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 9,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 12.58,
+                              "Total Cost": 24.52,
+                              "Plan Rows": 2,
+                              "Plan Width": 108,
+                              "Actual Startup Time": 0.007,
+                              "Actual Total Time": 0.017,
+                              "Actual Rows": 12,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "customer.c_custkey",
+                                "n2.n_name"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(customer.c_nationkey = n2.n_nationkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "customer",
+                                  "Schema": "pg_temp",
+                                  "Alias": "customer",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.4,
+                                  "Plan Rows": 140,
+                                  "Plan Width": 8,
+                                  "Actual Startup Time": 0.001,
+                                  "Actual Total Time": 0.005,
+                                  "Actual Rows": 129,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "customer.c_custkey",
+                                    "customer.c_name",
+                                    "customer.c_address",
+                                    "customer.c_nationkey",
+                                    "customer.c_phone",
+                                    "customer.c_acctbal",
+                                    "customer.c_mktsegment",
+                                    "customer.c_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 12.55,
+                                  "Total Cost": 12.55,
+                                  "Plan Rows": 2,
+                                  "Plan Width": 108,
+                                  "Actual Startup Time": 0.004,
+                                  "Actual Total Time": 0.005,
+                                  "Actual Rows": 2,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "n2.n_name",
+                                    "n2.n_nationkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 9,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Relation Name": "nation",
+                                      "Schema": "pg_temp",
+                                      "Alias": "n2",
+                                      "Startup Cost": 0.0,
+                                      "Total Cost": 12.55,
+                                      "Plan Rows": 2,
+                                      "Plan Width": 108,
+                                      "Actual Startup Time": 0.002,
+                                      "Actual Total Time": 0.004,
+                                      "Actual Rows": 2,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "n2.n_name",
+                                        "n2.n_nationkey"
+                                      ],
+                                      "Filter": "((n2.n_name = 'GERMANY'::bpchar) OR (n2.n_name = 'FRANCE'::bpchar))",
+                                      "Rows Removed by Filter": 23
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Node Type": "Hash Join",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 12.58,
+                  "Total Cost": 24.66,
+                  "Plan Rows": 2,
+                  "Plan Width": 108,
+                  "Actual Startup Time": 0.002,
+                  "Actual Total Time": 0.04,
+                  "Actual Rows": 44,
+                  "Actual Loops": 30,
+                  "Output": [
+                    "supplier.s_suppkey",
+                    "n1.n_name"
+                  ],
+                  "Inner Unique": false,
+                  "Hash Cond": "(supplier.s_nationkey = n1.n_nationkey)",
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "supplier",
+                      "Schema": "pg_temp",
+                      "Alias": "supplier",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 11.5,
+                      "Plan Rows": 150,
+                      "Plan Width": 8,
+                      "Actual Startup Time": 0.001,
+                      "Actual Total Time": 0.018,
+                      "Actual Rows": 518,
+                      "Actual Loops": 30,
+                      "Output": [
+                        "supplier.s_suppkey",
+                        "supplier.s_name",
+                        "supplier.s_address",
+                        "supplier.s_nationkey",
+                        "supplier.s_phone",
+                        "supplier.s_acctbal",
+                        "supplier.s_comment"
+                      ]
+                    },
+                    {
+                      "Node Type": "Hash",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Startup Cost": 12.55,
+                      "Total Cost": 12.55,
+                      "Plan Rows": 2,
+                      "Plan Width": 108,
+                      "Actual Startup Time": 0.004,
+                      "Actual Total Time": 0.004,
+                      "Actual Rows": 2,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "n1.n_name",
+                        "n1.n_nationkey"
+                      ],
+                      "Hash Buckets": 1024,
+                      "Original Hash Buckets": 1024,
+                      "Hash Batches": 1,
+                      "Original Hash Batches": 1,
+                      "Peak Memory Usage": 9,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "nation",
+                          "Schema": "pg_temp",
+                          "Alias": "n1",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.55,
+                          "Plan Rows": 2,
+                          "Plan Width": 108,
+                          "Actual Startup Time": 0.002,
+                          "Actual Total Time": 0.003,
+                          "Actual Rows": 2,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "n1.n_name",
+                            "n1.n_nationkey"
+                          ],
+                          "Filter": "((n1.n_name = 'FRANCE'::bpchar) OR (n1.n_name = 'GERMANY'::bpchar))",
+                          "Rows Removed by Filter": 23
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.151,
+    "Triggers": [],
+    "Execution Time": 4.106
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q8-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q8-analyze.plan.json
@@ -1,1 +1,583 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 100.04, "Total Cost": 100.08, "Plan Rows": 1, "Plan Width": 64, "Actual Startup Time": 7.77, "Actual Total Time": 7.775, "Actual Rows": 1, "Actual Loops": 1, "Output": ["(EXTRACT(year FROM orders.o_orderdate))", "(sum(CASE WHEN (n2.n_name = 'BRAZIL'::bpchar) THEN (lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)) ELSE '0'::numeric END) / sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))"], "Group Key": ["(EXTRACT(year FROM orders.o_orderdate))"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 100.04, "Total Cost": 100.04, "Plan Rows": 1, "Plan Width": 168, "Actual Startup Time": 7.757, "Actual Total Time": 7.762, "Actual Rows": 1, "Actual Loops": 1, "Output": ["(EXTRACT(year FROM orders.o_orderdate))", "n2.n_name", "lineitem.l_extendedprice", "lineitem.l_discount"], "Sort Key": ["(EXTRACT(year FROM orders.o_orderdate))"], "Sort Method": "quicksort", "Sort Space Used": 25, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 62.11, "Total Cost": 100.03, "Plan Rows": 1, "Plan Width": 168, "Actual Startup Time": 6.773, "Actual Total Time": 7.748, "Actual Rows": 1, "Actual Loops": 1, "Output": ["EXTRACT(year FROM orders.o_orderdate)", "n2.n_name", "lineitem.l_extendedprice", "lineitem.l_discount"], "Inner Unique": false, "Join Filter": "(lineitem.l_partkey = part.p_partkey)", "Rows Removed by Join Filter": 143, "Plans": [{"Node Type": "Nested Loop", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 62.11, "Total Cost": 86.81, "Plan Rows": 1, "Plan Width": 144, "Actual Startup Time": 1.126, "Actual Total Time": 1.696, "Actual Rows": 48, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey", "orders.o_orderdate", "n2.n_name"], "Inner Unique": false, "Join Filter": "(n1.n_nationkey = customer.c_nationkey)", "Rows Removed by Join Filter": 1107, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 12.14, "Total Cost": 24.48, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.038, "Actual Total Time": 0.048, "Actual Rows": 5, "Actual Loops": 1, "Output": ["n1.n_nationkey"], "Inner Unique": false, "Hash Cond": "(n1.n_regionkey = region.r_regionkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "n1", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 8, "Actual Startup Time": 0.007, "Actual Total Time": 0.01, "Actual Rows": 25, "Actual Loops": 1, "Output": ["n1.n_nationkey", "n1.n_name", "n1.n_regionkey", "n1.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 12.12, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.011, "Actual Total Time": 0.012, "Actual Rows": 1, "Actual Loops": 1, "Output": ["region.r_regionkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "region", "Schema": "pg_temp", "Alias": "region", "Startup Cost": 0.0, "Total Cost": 12.12, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.006, "Actual Total Time": 0.008, "Actual Rows": 1, "Actual Loops": 1, "Output": ["region.r_regionkey"], "Filter": "(region.r_name = 'AMERICA'::bpchar)", "Rows Removed by Filter": 4}]}]}, {"Node Type": "Hash Join", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 49.97, "Total Cost": 62.31, "Plan Rows": 1, "Plan Width": 148, "Actual Startup Time": 0.218, "Actual Total Time": 0.301, "Actual Rows": 231, "Actual Loops": 5, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey", "orders.o_orderdate", "customer.c_nationkey", "n2.n_name"], "Inner Unique": false, "Hash Cond": "(n2.n_nationkey = supplier.s_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "n2", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 108, "Actual Startup Time": 0.001, "Actual Total Time": 0.005, "Actual Rows": 25, "Actual Loops": 5, "Output": ["n2.n_nationkey", "n2.n_name", "n2.n_regionkey", "n2.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 49.95, "Total Cost": 49.95, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 1.069, "Actual Total Time": 1.071, "Actual Rows": 231, "Actual Loops": 1, "Output": ["supplier.s_nationkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey", "orders.o_orderdate", "customer.c_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 23, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 37.88, "Total Cost": 49.95, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.656, "Actual Total Time": 0.951, "Actual Rows": 231, "Actual Loops": 1, "Output": ["supplier.s_nationkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey", "orders.o_orderdate", "customer.c_nationkey"], "Inner Unique": false, "Hash Cond": "(supplier.s_suppkey = lineitem.l_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.004, "Actual Total Time": 0.093, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 37.87, "Total Cost": 37.87, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.631, "Actual Total Time": 0.633, "Actual Rows": 231, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey", "lineitem.l_suppkey", "orders.o_orderdate", "customer.c_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 23, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 25.11, "Total Cost": 37.87, "Plan Rows": 1, "Plan Width": 48, "Actual Startup Time": 0.212, "Actual Total Time": 0.508, "Actual Rows": 231, "Actual Loops": 1, "Output": ["lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_partkey", "lineitem.l_suppkey", "orders.o_orderdate", "customer.c_nationkey"], "Inner Unique": false, "Hash Cond": "(lineitem.l_orderkey = orders.o_orderkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 44, "Actual Startup Time": 0.004, "Actual Total Time": 0.103, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 25.1, "Total Cost": 25.1, "Plan Rows": 1, "Plan Width": 12, "Actual Startup Time": 0.181, "Actual Total Time": 0.182, "Actual Rows": 47, "Actual Loops": 1, "Output": ["orders.o_orderdate", "orders.o_orderkey", "customer.c_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 11, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 13.16, "Total Cost": 25.1, "Plan Rows": 1, "Plan Width": 12, "Actual Startup Time": 0.095, "Actual Total Time": 0.159, "Actual Rows": 47, "Actual Loops": 1, "Output": ["orders.o_orderdate", "orders.o_orderkey", "customer.c_nationkey"], "Inner Unique": false, "Hash Cond": "(customer.c_custkey = orders.o_custkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "customer", "Schema": "pg_temp", "Alias": "customer", "Startup Cost": 0.0, "Total Cost": 11.4, "Plan Rows": 140, "Plan Width": 8, "Actual Startup Time": 0.004, "Actual Total Time": 0.024, "Actual Rows": 129, "Actual Loops": 1, "Output": ["customer.c_custkey", "customer.c_name", "customer.c_address", "customer.c_nationkey", "customer.c_phone", "customer.c_acctbal", "customer.c_mktsegment", "customer.c_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.15, "Total Cost": 13.15, "Plan Rows": 1, "Plan Width": 12, "Actual Startup Time": 0.065, "Actual Total Time": 0.066, "Actual Rows": 47, "Actual Loops": 1, "Output": ["orders.o_orderdate", "orders.o_orderkey", "orders.o_custkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 11, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 13.15, "Plan Rows": 1, "Plan Width": 12, "Actual Startup Time": 0.008, "Actual Total Time": 0.042, "Actual Rows": 47, "Actual Loops": 1, "Output": ["orders.o_orderdate", "orders.o_orderkey", "orders.o_custkey"], "Filter": "((orders.o_orderdate >= '1995-01-01'::date) AND (orders.o_orderdate <= '1996-12-31'::date))", "Rows Removed by Filter": 81}]}]}]}]}]}]}]}]}]}, {"Node Type": "Seq Scan", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 13.2, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.024, "Actual Total Time": 0.125, "Actual Rows": 3, "Actual Loops": 48, "Output": ["part.p_partkey", "part.p_name", "part.p_mfgr", "part.p_brand", "part.p_type", "part.p_size", "part.p_container", "part.p_retailprice", "part.p_comment"], "Filter": "((part.p_type)::text = 'ECONOMY ANODIZED STEEL'::text)", "Rows Removed by Filter": 530}]}]}]}, "Planning Time": 1.223, "Triggers": [], "Execution Time": 7.876}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 100.04,
+      "Total Cost": 100.08,
+      "Plan Rows": 1,
+      "Plan Width": 64,
+      "Actual Startup Time": 1.798,
+      "Actual Total Time": 1.8,
+      "Actual Rows": 1,
+      "Actual Loops": 1,
+      "Output": [
+        "(EXTRACT(year FROM orders.o_orderdate))",
+        "(sum(CASE WHEN (n2.n_name = 'BRAZIL'::bpchar) THEN (lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)) ELSE '0'::numeric END) / sum((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount))))"
+      ],
+      "Group Key": [
+        "(EXTRACT(year FROM orders.o_orderdate))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 100.04,
+          "Total Cost": 100.04,
+          "Plan Rows": 1,
+          "Plan Width": 168,
+          "Actual Startup Time": 1.795,
+          "Actual Total Time": 1.796,
+          "Actual Rows": 1,
+          "Actual Loops": 1,
+          "Output": [
+            "(EXTRACT(year FROM orders.o_orderdate))",
+            "n2.n_name",
+            "lineitem.l_extendedprice",
+            "lineitem.l_discount"
+          ],
+          "Sort Key": [
+            "(EXTRACT(year FROM orders.o_orderdate))"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 25,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Nested Loop",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 62.11,
+              "Total Cost": 100.03,
+              "Plan Rows": 1,
+              "Plan Width": 168,
+              "Actual Startup Time": 1.545,
+              "Actual Total Time": 1.794,
+              "Actual Rows": 1,
+              "Actual Loops": 1,
+              "Output": [
+                "EXTRACT(year FROM orders.o_orderdate)",
+                "n2.n_name",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount"
+              ],
+              "Inner Unique": false,
+              "Join Filter": "(part.p_partkey = lineitem.l_partkey)",
+              "Rows Removed by Join Filter": 143,
+              "Plans": [
+                {
+                  "Node Type": "Nested Loop",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Join Type": "Inner",
+                  "Startup Cost": 62.11,
+                  "Total Cost": 86.81,
+                  "Plan Rows": 1,
+                  "Plan Width": 144,
+                  "Actual Startup Time": 0.217,
+                  "Actual Total Time": 0.348,
+                  "Actual Rows": 48,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount",
+                    "lineitem.l_partkey",
+                    "orders.o_orderdate",
+                    "n2.n_name"
+                  ],
+                  "Inner Unique": false,
+                  "Join Filter": "(customer.c_nationkey = n1.n_nationkey)",
+                  "Rows Removed by Join Filter": 1107,
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 12.14,
+                      "Total Cost": 24.48,
+                      "Plan Rows": 1,
+                      "Plan Width": 4,
+                      "Actual Startup Time": 0.006,
+                      "Actual Total Time": 0.009,
+                      "Actual Rows": 5,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "n1.n_nationkey"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(n1.n_regionkey = region.r_regionkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "nation",
+                          "Schema": "pg_temp",
+                          "Alias": "n1",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.7,
+                          "Plan Rows": 170,
+                          "Plan Width": 8,
+                          "Actual Startup Time": 0.002,
+                          "Actual Total Time": 0.003,
+                          "Actual Rows": 25,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "n1.n_nationkey",
+                            "n1.n_name",
+                            "n1.n_regionkey",
+                            "n1.n_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 12.12,
+                          "Total Cost": 12.12,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Actual Startup Time": 0.003,
+                          "Actual Total Time": 0.003,
+                          "Actual Rows": 1,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "region.r_regionkey"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 9,
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Relation Name": "region",
+                              "Schema": "pg_temp",
+                              "Alias": "region",
+                              "Startup Cost": 0.0,
+                              "Total Cost": 12.12,
+                              "Plan Rows": 1,
+                              "Plan Width": 4,
+                              "Actual Startup Time": 0.002,
+                              "Actual Total Time": 0.002,
+                              "Actual Rows": 1,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "region.r_regionkey"
+                              ],
+                              "Filter": "(region.r_name = 'AMERICA'::bpchar)",
+                              "Rows Removed by Filter": 4
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Inner",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 49.97,
+                      "Total Cost": 62.31,
+                      "Plan Rows": 1,
+                      "Plan Width": 148,
+                      "Actual Startup Time": 0.042,
+                      "Actual Total Time": 0.06,
+                      "Actual Rows": 231,
+                      "Actual Loops": 5,
+                      "Output": [
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount",
+                        "lineitem.l_partkey",
+                        "orders.o_orderdate",
+                        "customer.c_nationkey",
+                        "n2.n_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(n2.n_nationkey = supplier.s_nationkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "nation",
+                          "Schema": "pg_temp",
+                          "Alias": "n2",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 11.7,
+                          "Plan Rows": 170,
+                          "Plan Width": 108,
+                          "Actual Startup Time": 0.0,
+                          "Actual Total Time": 0.001,
+                          "Actual Rows": 25,
+                          "Actual Loops": 5,
+                          "Output": [
+                            "n2.n_nationkey",
+                            "n2.n_name",
+                            "n2.n_regionkey",
+                            "n2.n_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 49.95,
+                          "Total Cost": 49.95,
+                          "Plan Rows": 1,
+                          "Plan Width": 48,
+                          "Actual Startup Time": 0.207,
+                          "Actual Total Time": 0.208,
+                          "Actual Rows": 231,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "supplier.s_nationkey",
+                            "lineitem.l_extendedprice",
+                            "lineitem.l_discount",
+                            "lineitem.l_partkey",
+                            "orders.o_orderdate",
+                            "customer.c_nationkey"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 23,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 37.88,
+                              "Total Cost": 49.95,
+                              "Plan Rows": 1,
+                              "Plan Width": 48,
+                              "Actual Startup Time": 0.124,
+                              "Actual Total Time": 0.187,
+                              "Actual Rows": 231,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "supplier.s_nationkey",
+                                "lineitem.l_extendedprice",
+                                "lineitem.l_discount",
+                                "lineitem.l_partkey",
+                                "orders.o_orderdate",
+                                "customer.c_nationkey"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(supplier.s_suppkey = lineitem.l_suppkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "supplier",
+                                  "Schema": "pg_temp",
+                                  "Alias": "supplier",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.5,
+                                  "Plan Rows": 150,
+                                  "Plan Width": 8,
+                                  "Actual Startup Time": 0.001,
+                                  "Actual Total Time": 0.02,
+                                  "Actual Rows": 518,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "supplier.s_suppkey",
+                                    "supplier.s_name",
+                                    "supplier.s_address",
+                                    "supplier.s_nationkey",
+                                    "supplier.s_phone",
+                                    "supplier.s_acctbal",
+                                    "supplier.s_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 37.87,
+                                  "Total Cost": 37.87,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 48,
+                                  "Actual Startup Time": 0.121,
+                                  "Actual Total Time": 0.121,
+                                  "Actual Rows": 231,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "lineitem.l_extendedprice",
+                                    "lineitem.l_discount",
+                                    "lineitem.l_partkey",
+                                    "lineitem.l_suppkey",
+                                    "orders.o_orderdate",
+                                    "customer.c_nationkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 23,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Hash Join",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Join Type": "Inner",
+                                      "Startup Cost": 25.11,
+                                      "Total Cost": 37.87,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 48,
+                                      "Actual Startup Time": 0.037,
+                                      "Actual Total Time": 0.1,
+                                      "Actual Rows": 231,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "lineitem.l_extendedprice",
+                                        "lineitem.l_discount",
+                                        "lineitem.l_partkey",
+                                        "lineitem.l_suppkey",
+                                        "orders.o_orderdate",
+                                        "customer.c_nationkey"
+                                      ],
+                                      "Inner Unique": false,
+                                      "Hash Cond": "(lineitem.l_orderkey = orders.o_orderkey)",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "lineitem",
+                                          "Schema": "pg_temp",
+                                          "Alias": "lineitem",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 12.0,
+                                          "Plan Rows": 200,
+                                          "Plan Width": 44,
+                                          "Actual Startup Time": 0.002,
+                                          "Actual Total Time": 0.022,
+                                          "Actual Rows": 572,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "lineitem.l_orderkey",
+                                            "lineitem.l_partkey",
+                                            "lineitem.l_suppkey",
+                                            "lineitem.l_linenumber",
+                                            "lineitem.l_quantity",
+                                            "lineitem.l_extendedprice",
+                                            "lineitem.l_discount",
+                                            "lineitem.l_tax",
+                                            "lineitem.l_returnflag",
+                                            "lineitem.l_linestatus",
+                                            "lineitem.l_shipdate",
+                                            "lineitem.l_commitdate",
+                                            "lineitem.l_receiptdate",
+                                            "lineitem.l_shipinstruct",
+                                            "lineitem.l_shipmode",
+                                            "lineitem.l_comment"
+                                          ]
+                                        },
+                                        {
+                                          "Node Type": "Hash",
+                                          "Parent Relationship": "Inner",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Startup Cost": 25.1,
+                                          "Total Cost": 25.1,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 12,
+                                          "Actual Startup Time": 0.032,
+                                          "Actual Total Time": 0.032,
+                                          "Actual Rows": 47,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "orders.o_orderdate",
+                                            "orders.o_orderkey",
+                                            "customer.c_nationkey"
+                                          ],
+                                          "Hash Buckets": 1024,
+                                          "Original Hash Buckets": 1024,
+                                          "Hash Batches": 1,
+                                          "Original Hash Batches": 1,
+                                          "Peak Memory Usage": 11,
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Hash Join",
+                                              "Parent Relationship": "Outer",
+                                              "Parallel Aware": false,
+                                              "Async Capable": false,
+                                              "Join Type": "Inner",
+                                              "Startup Cost": 13.16,
+                                              "Total Cost": 25.1,
+                                              "Plan Rows": 1,
+                                              "Plan Width": 12,
+                                              "Actual Startup Time": 0.016,
+                                              "Actual Total Time": 0.029,
+                                              "Actual Rows": 47,
+                                              "Actual Loops": 1,
+                                              "Output": [
+                                                "orders.o_orderdate",
+                                                "orders.o_orderkey",
+                                                "customer.c_nationkey"
+                                              ],
+                                              "Inner Unique": false,
+                                              "Hash Cond": "(customer.c_custkey = orders.o_custkey)",
+                                              "Plans": [
+                                                {
+                                                  "Node Type": "Seq Scan",
+                                                  "Parent Relationship": "Outer",
+                                                  "Parallel Aware": false,
+                                                  "Async Capable": false,
+                                                  "Relation Name": "customer",
+                                                  "Schema": "pg_temp",
+                                                  "Alias": "customer",
+                                                  "Startup Cost": 0.0,
+                                                  "Total Cost": 11.4,
+                                                  "Plan Rows": 140,
+                                                  "Plan Width": 8,
+                                                  "Actual Startup Time": 0.001,
+                                                  "Actual Total Time": 0.005,
+                                                  "Actual Rows": 129,
+                                                  "Actual Loops": 1,
+                                                  "Output": [
+                                                    "customer.c_custkey",
+                                                    "customer.c_name",
+                                                    "customer.c_address",
+                                                    "customer.c_nationkey",
+                                                    "customer.c_phone",
+                                                    "customer.c_acctbal",
+                                                    "customer.c_mktsegment",
+                                                    "customer.c_comment"
+                                                  ]
+                                                },
+                                                {
+                                                  "Node Type": "Hash",
+                                                  "Parent Relationship": "Inner",
+                                                  "Parallel Aware": false,
+                                                  "Async Capable": false,
+                                                  "Startup Cost": 13.15,
+                                                  "Total Cost": 13.15,
+                                                  "Plan Rows": 1,
+                                                  "Plan Width": 12,
+                                                  "Actual Startup Time": 0.013,
+                                                  "Actual Total Time": 0.013,
+                                                  "Actual Rows": 47,
+                                                  "Actual Loops": 1,
+                                                  "Output": [
+                                                    "orders.o_orderdate",
+                                                    "orders.o_orderkey",
+                                                    "orders.o_custkey"
+                                                  ],
+                                                  "Hash Buckets": 1024,
+                                                  "Original Hash Buckets": 1024,
+                                                  "Hash Batches": 1,
+                                                  "Original Hash Batches": 1,
+                                                  "Peak Memory Usage": 11,
+                                                  "Plans": [
+                                                    {
+                                                      "Node Type": "Seq Scan",
+                                                      "Parent Relationship": "Outer",
+                                                      "Parallel Aware": false,
+                                                      "Async Capable": false,
+                                                      "Relation Name": "orders",
+                                                      "Schema": "pg_temp",
+                                                      "Alias": "orders",
+                                                      "Startup Cost": 0.0,
+                                                      "Total Cost": 13.15,
+                                                      "Plan Rows": 1,
+                                                      "Plan Width": 12,
+                                                      "Actual Startup Time": 0.002,
+                                                      "Actual Total Time": 0.01,
+                                                      "Actual Rows": 47,
+                                                      "Actual Loops": 1,
+                                                      "Output": [
+                                                        "orders.o_orderdate",
+                                                        "orders.o_orderkey",
+                                                        "orders.o_custkey"
+                                                      ],
+                                                      "Filter": "((orders.o_orderdate >= '1995-01-01'::date) AND (orders.o_orderdate <= '1996-12-31'::date))",
+                                                      "Rows Removed by Filter": 81
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "part",
+                  "Schema": "pg_temp",
+                  "Alias": "part",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 13.2,
+                  "Plan Rows": 1,
+                  "Plan Width": 4,
+                  "Actual Startup Time": 0.005,
+                  "Actual Total Time": 0.029,
+                  "Actual Rows": 3,
+                  "Actual Loops": 48,
+                  "Output": [
+                    "part.p_partkey",
+                    "part.p_name",
+                    "part.p_mfgr",
+                    "part.p_brand",
+                    "part.p_type",
+                    "part.p_size",
+                    "part.p_container",
+                    "part.p_retailprice",
+                    "part.p_comment"
+                  ],
+                  "Filter": "((part.p_type)::text = 'ECONOMY ANODIZED STEEL'::text)",
+                  "Rows Removed by Filter": 530
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.22,
+    "Triggers": [],
+    "Execution Time": 1.819
+  }
+]

--- a/standalone-app/examples/postgres/tpch/tpch-q9-analyze.plan.json
+++ b/standalone-app/examples/postgres/tpch/tpch-q9-analyze.plan.json
@@ -1,1 +1,517 @@
-[{"Plan": {"Node Type": "Aggregate", "Strategy": "Sorted", "Partial Mode": "Simple", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 76.34, "Total Cost": 76.38, "Plan Rows": 1, "Plan Width": 168, "Actual Startup Time": 0.342, "Actual Total Time": 0.369, "Actual Rows": 27, "Actual Loops": 1, "Output": ["nation.n_name", "(EXTRACT(year FROM orders.o_orderdate))", "sum(((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))"], "Group Key": ["nation.n_name", "(EXTRACT(year FROM orders.o_orderdate))"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 76.34, "Total Cost": 76.35, "Plan Rows": 1, "Plan Width": 200, "Actual Startup Time": 0.337, "Actual Total Time": 0.339, "Actual Rows": 28, "Actual Loops": 1, "Output": ["nation.n_name", "(EXTRACT(year FROM orders.o_orderdate))", "lineitem.l_extendedprice", "lineitem.l_discount", "partsupp.ps_supplycost", "lineitem.l_quantity"], "Sort Key": ["nation.n_name", "(EXTRACT(year FROM orders.o_orderdate)) DESC"], "Sort Method": "quicksort", "Sort Space Used": 27, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 63.34, "Total Cost": 76.33, "Plan Rows": 1, "Plan Width": 200, "Actual Startup Time": 0.256, "Actual Total Time": 0.318, "Actual Rows": 28, "Actual Loops": 1, "Output": ["nation.n_name", "EXTRACT(year FROM orders.o_orderdate)", "lineitem.l_extendedprice", "lineitem.l_discount", "partsupp.ps_supplycost", "lineitem.l_quantity"], "Inner Unique": false, "Hash Cond": "((partsupp.ps_suppkey = supplier.s_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey))", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "partsupp", "Schema": "pg_temp", "Alias": "partsupp", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 24, "Actual Startup Time": 0.005, "Actual Total Time": 0.028, "Actual Rows": 537, "Actual Loops": 1, "Output": ["partsupp.ps_partkey", "partsupp.ps_suppkey", "partsupp.ps_availqty", "partsupp.ps_supplycost", "partsupp.ps_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 63.33, "Total Cost": 63.33, "Plan Rows": 1, "Plan Width": 172, "Actual Startup Time": 0.245, "Actual Total Time": 0.246, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "supplier.s_suppkey", "orders.o_orderdate", "nation.n_name"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 11, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 50.43, "Total Cost": 63.33, "Plan Rows": 1, "Plan Width": 172, "Actual Startup Time": 0.224, "Actual Total Time": 0.241, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "supplier.s_suppkey", "orders.o_orderdate", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(orders.o_orderkey = lineitem.l_orderkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "orders", "Schema": "pg_temp", "Alias": "orders", "Startup Cost": 0.0, "Total Cost": 12.1, "Plan Rows": 210, "Plan Width": 8, "Actual Startup Time": 0.002, "Actual Total Time": 0.007, "Actual Rows": 128, "Actual Loops": 1, "Output": ["orders.o_orderkey", "orders.o_custkey", "orders.o_orderstatus", "orders.o_totalprice", "orders.o_orderdate", "orders.o_orderpriority", "orders.o_clerk", "orders.o_shippriority", "orders.o_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 50.42, "Total Cost": 50.42, "Plan Rows": 1, "Plan Width": 172, "Actual Startup Time": 0.22, "Actual Total Time": 0.221, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "lineitem.l_orderkey", "supplier.s_suppkey", "nation.n_name"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 11, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 38.07, "Total Cost": 50.42, "Plan Rows": 1, "Plan Width": 172, "Actual Startup Time": 0.209, "Actual Total Time": 0.215, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "lineitem.l_orderkey", "supplier.s_suppkey", "nation.n_name"], "Inner Unique": false, "Hash Cond": "(nation.n_nationkey = supplier.s_nationkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "nation", "Schema": "pg_temp", "Alias": "nation", "Startup Cost": 0.0, "Total Cost": 11.7, "Plan Rows": 170, "Plan Width": 108, "Actual Startup Time": 0.002, "Actual Total Time": 0.003, "Actual Rows": 25, "Actual Loops": 1, "Output": ["nation.n_nationkey", "nation.n_name", "nation.n_regionkey", "nation.n_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 38.06, "Total Cost": 38.06, "Plan Rows": 1, "Plan Width": 72, "Actual Startup Time": 0.205, "Actual Total Time": 0.206, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "lineitem.l_orderkey", "supplier.s_suppkey", "supplier.s_nationkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 11, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 25.98, "Total Cost": 38.06, "Plan Rows": 1, "Plan Width": 72, "Actual Startup Time": 0.144, "Actual Total Time": 0.2, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "lineitem.l_orderkey", "supplier.s_suppkey", "supplier.s_nationkey"], "Inner Unique": false, "Hash Cond": "(supplier.s_suppkey = lineitem.l_suppkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "supplier", "Schema": "pg_temp", "Alias": "supplier", "Startup Cost": 0.0, "Total Cost": 11.5, "Plan Rows": 150, "Plan Width": 8, "Actual Startup Time": 0.001, "Actual Total Time": 0.027, "Actual Rows": 518, "Actual Loops": 1, "Output": ["supplier.s_suppkey", "supplier.s_name", "supplier.s_address", "supplier.s_nationkey", "supplier.s_phone", "supplier.s_acctbal", "supplier.s_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 25.97, "Total Cost": 25.97, "Plan Rows": 1, "Plan Width": 64, "Actual Startup Time": 0.14, "Actual Total Time": 0.141, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "lineitem.l_orderkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 10, "Plans": [{"Node Type": "Hash Join", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Join Type": "Inner", "Startup Cost": 13.21, "Total Cost": 25.97, "Plan Rows": 1, "Plan Width": 64, "Actual Startup Time": 0.072, "Actual Total Time": 0.136, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_quantity", "lineitem.l_suppkey", "lineitem.l_partkey", "lineitem.l_orderkey"], "Inner Unique": false, "Hash Cond": "(lineitem.l_partkey = part.p_partkey)", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 60, "Actual Startup Time": 0.001, "Actual Total Time": 0.029, "Actual Rows": 572, "Actual Loops": 1, "Output": ["lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey", "lineitem.l_linenumber", "lineitem.l_quantity", "lineitem.l_extendedprice", "lineitem.l_discount", "lineitem.l_tax", "lineitem.l_returnflag", "lineitem.l_linestatus", "lineitem.l_shipdate", "lineitem.l_commitdate", "lineitem.l_receiptdate", "lineitem.l_shipinstruct", "lineitem.l_shipmode", "lineitem.l_comment"]}, {"Node Type": "Hash", "Parent Relationship": "Inner", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 13.2, "Total Cost": 13.2, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.069, "Actual Total Time": 0.069, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey"], "Hash Buckets": 1024, "Original Hash Buckets": 1024, "Hash Batches": 1, "Original Hash Batches": 1, "Peak Memory Usage": 9, "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "part", "Schema": "pg_temp", "Alias": "part", "Startup Cost": 0.0, "Total Cost": 13.2, "Plan Rows": 1, "Plan Width": 4, "Actual Startup Time": 0.003, "Actual Total Time": 0.065, "Actual Rows": 28, "Actual Loops": 1, "Output": ["part.p_partkey"], "Filter": "((part.p_name)::text ~~ '%green%'::text)", "Rows Removed by Filter": 505}]}]}]}]}]}]}]}]}]}]}]}]}, "Planning Time": 0.294, "Triggers": [], "Execution Time": 0.405}]
+[
+  {
+    "Plan": {
+      "Node Type": "Aggregate",
+      "Strategy": "Sorted",
+      "Partial Mode": "Simple",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 76.34,
+      "Total Cost": 76.38,
+      "Plan Rows": 1,
+      "Plan Width": 168,
+      "Actual Startup Time": 0.272,
+      "Actual Total Time": 0.29,
+      "Actual Rows": 27,
+      "Actual Loops": 1,
+      "Output": [
+        "nation.n_name",
+        "(EXTRACT(year FROM orders.o_orderdate))",
+        "sum(((lineitem.l_extendedprice * ('1'::numeric - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))"
+      ],
+      "Group Key": [
+        "nation.n_name",
+        "(EXTRACT(year FROM orders.o_orderdate))"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 76.34,
+          "Total Cost": 76.35,
+          "Plan Rows": 1,
+          "Plan Width": 200,
+          "Actual Startup Time": 0.269,
+          "Actual Total Time": 0.271,
+          "Actual Rows": 28,
+          "Actual Loops": 1,
+          "Output": [
+            "nation.n_name",
+            "(EXTRACT(year FROM orders.o_orderdate))",
+            "lineitem.l_extendedprice",
+            "lineitem.l_discount",
+            "partsupp.ps_supplycost",
+            "lineitem.l_quantity"
+          ],
+          "Sort Key": [
+            "nation.n_name",
+            "(EXTRACT(year FROM orders.o_orderdate)) DESC"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 27,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Inner",
+              "Startup Cost": 63.34,
+              "Total Cost": 76.33,
+              "Plan Rows": 1,
+              "Plan Width": 200,
+              "Actual Startup Time": 0.186,
+              "Actual Total Time": 0.231,
+              "Actual Rows": 28,
+              "Actual Loops": 1,
+              "Output": [
+                "nation.n_name",
+                "EXTRACT(year FROM orders.o_orderdate)",
+                "lineitem.l_extendedprice",
+                "lineitem.l_discount",
+                "partsupp.ps_supplycost",
+                "lineitem.l_quantity"
+              ],
+              "Inner Unique": false,
+              "Hash Cond": "((partsupp.ps_suppkey = supplier.s_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey))",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Relation Name": "partsupp",
+                  "Schema": "pg_temp",
+                  "Alias": "partsupp",
+                  "Startup Cost": 0.0,
+                  "Total Cost": 11.7,
+                  "Plan Rows": 170,
+                  "Plan Width": 24,
+                  "Actual Startup Time": 0.004,
+                  "Actual Total Time": 0.023,
+                  "Actual Rows": 537,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "partsupp.ps_partkey",
+                    "partsupp.ps_suppkey",
+                    "partsupp.ps_availqty",
+                    "partsupp.ps_supplycost",
+                    "partsupp.ps_comment"
+                  ]
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 63.33,
+                  "Total Cost": 63.33,
+                  "Plan Rows": 1,
+                  "Plan Width": 172,
+                  "Actual Startup Time": 0.179,
+                  "Actual Total Time": 0.179,
+                  "Actual Rows": 28,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "part.p_partkey",
+                    "lineitem.l_extendedprice",
+                    "lineitem.l_discount",
+                    "lineitem.l_quantity",
+                    "lineitem.l_suppkey",
+                    "lineitem.l_partkey",
+                    "supplier.s_suppkey",
+                    "orders.o_orderdate",
+                    "nation.n_name"
+                  ],
+                  "Hash Buckets": 1024,
+                  "Original Hash Buckets": 1024,
+                  "Hash Batches": 1,
+                  "Original Hash Batches": 1,
+                  "Peak Memory Usage": 11,
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Join Type": "Inner",
+                      "Startup Cost": 50.43,
+                      "Total Cost": 63.33,
+                      "Plan Rows": 1,
+                      "Plan Width": 172,
+                      "Actual Startup Time": 0.163,
+                      "Actual Total Time": 0.175,
+                      "Actual Rows": 28,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "part.p_partkey",
+                        "lineitem.l_extendedprice",
+                        "lineitem.l_discount",
+                        "lineitem.l_quantity",
+                        "lineitem.l_suppkey",
+                        "lineitem.l_partkey",
+                        "supplier.s_suppkey",
+                        "orders.o_orderdate",
+                        "nation.n_name"
+                      ],
+                      "Inner Unique": false,
+                      "Hash Cond": "(orders.o_orderkey = lineitem.l_orderkey)",
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Outer",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Relation Name": "orders",
+                          "Schema": "pg_temp",
+                          "Alias": "orders",
+                          "Startup Cost": 0.0,
+                          "Total Cost": 12.1,
+                          "Plan Rows": 210,
+                          "Plan Width": 8,
+                          "Actual Startup Time": 0.001,
+                          "Actual Total Time": 0.005,
+                          "Actual Rows": 128,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "orders.o_orderkey",
+                            "orders.o_custkey",
+                            "orders.o_orderstatus",
+                            "orders.o_totalprice",
+                            "orders.o_orderdate",
+                            "orders.o_orderpriority",
+                            "orders.o_clerk",
+                            "orders.o_shippriority",
+                            "orders.o_comment"
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Parallel Aware": false,
+                          "Async Capable": false,
+                          "Startup Cost": 50.42,
+                          "Total Cost": 50.42,
+                          "Plan Rows": 1,
+                          "Plan Width": 172,
+                          "Actual Startup Time": 0.16,
+                          "Actual Total Time": 0.161,
+                          "Actual Rows": 28,
+                          "Actual Loops": 1,
+                          "Output": [
+                            "part.p_partkey",
+                            "lineitem.l_extendedprice",
+                            "lineitem.l_discount",
+                            "lineitem.l_quantity",
+                            "lineitem.l_suppkey",
+                            "lineitem.l_partkey",
+                            "lineitem.l_orderkey",
+                            "supplier.s_suppkey",
+                            "nation.n_name"
+                          ],
+                          "Hash Buckets": 1024,
+                          "Original Hash Buckets": 1024,
+                          "Hash Batches": 1,
+                          "Original Hash Batches": 1,
+                          "Peak Memory Usage": 11,
+                          "Plans": [
+                            {
+                              "Node Type": "Hash Join",
+                              "Parent Relationship": "Outer",
+                              "Parallel Aware": false,
+                              "Async Capable": false,
+                              "Join Type": "Inner",
+                              "Startup Cost": 38.07,
+                              "Total Cost": 50.42,
+                              "Plan Rows": 1,
+                              "Plan Width": 172,
+                              "Actual Startup Time": 0.152,
+                              "Actual Total Time": 0.157,
+                              "Actual Rows": 28,
+                              "Actual Loops": 1,
+                              "Output": [
+                                "part.p_partkey",
+                                "lineitem.l_extendedprice",
+                                "lineitem.l_discount",
+                                "lineitem.l_quantity",
+                                "lineitem.l_suppkey",
+                                "lineitem.l_partkey",
+                                "lineitem.l_orderkey",
+                                "supplier.s_suppkey",
+                                "nation.n_name"
+                              ],
+                              "Inner Unique": false,
+                              "Hash Cond": "(nation.n_nationkey = supplier.s_nationkey)",
+                              "Plans": [
+                                {
+                                  "Node Type": "Seq Scan",
+                                  "Parent Relationship": "Outer",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Relation Name": "nation",
+                                  "Schema": "pg_temp",
+                                  "Alias": "nation",
+                                  "Startup Cost": 0.0,
+                                  "Total Cost": 11.7,
+                                  "Plan Rows": 170,
+                                  "Plan Width": 108,
+                                  "Actual Startup Time": 0.001,
+                                  "Actual Total Time": 0.002,
+                                  "Actual Rows": 25,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "nation.n_nationkey",
+                                    "nation.n_name",
+                                    "nation.n_regionkey",
+                                    "nation.n_comment"
+                                  ]
+                                },
+                                {
+                                  "Node Type": "Hash",
+                                  "Parent Relationship": "Inner",
+                                  "Parallel Aware": false,
+                                  "Async Capable": false,
+                                  "Startup Cost": 38.06,
+                                  "Total Cost": 38.06,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 72,
+                                  "Actual Startup Time": 0.149,
+                                  "Actual Total Time": 0.15,
+                                  "Actual Rows": 28,
+                                  "Actual Loops": 1,
+                                  "Output": [
+                                    "part.p_partkey",
+                                    "lineitem.l_extendedprice",
+                                    "lineitem.l_discount",
+                                    "lineitem.l_quantity",
+                                    "lineitem.l_suppkey",
+                                    "lineitem.l_partkey",
+                                    "lineitem.l_orderkey",
+                                    "supplier.s_suppkey",
+                                    "supplier.s_nationkey"
+                                  ],
+                                  "Hash Buckets": 1024,
+                                  "Original Hash Buckets": 1024,
+                                  "Hash Batches": 1,
+                                  "Original Hash Batches": 1,
+                                  "Peak Memory Usage": 11,
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Hash Join",
+                                      "Parent Relationship": "Outer",
+                                      "Parallel Aware": false,
+                                      "Async Capable": false,
+                                      "Join Type": "Inner",
+                                      "Startup Cost": 25.98,
+                                      "Total Cost": 38.06,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 72,
+                                      "Actual Startup Time": 0.105,
+                                      "Actual Total Time": 0.146,
+                                      "Actual Rows": 28,
+                                      "Actual Loops": 1,
+                                      "Output": [
+                                        "part.p_partkey",
+                                        "lineitem.l_extendedprice",
+                                        "lineitem.l_discount",
+                                        "lineitem.l_quantity",
+                                        "lineitem.l_suppkey",
+                                        "lineitem.l_partkey",
+                                        "lineitem.l_orderkey",
+                                        "supplier.s_suppkey",
+                                        "supplier.s_nationkey"
+                                      ],
+                                      "Inner Unique": false,
+                                      "Hash Cond": "(supplier.s_suppkey = lineitem.l_suppkey)",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Seq Scan",
+                                          "Parent Relationship": "Outer",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Relation Name": "supplier",
+                                          "Schema": "pg_temp",
+                                          "Alias": "supplier",
+                                          "Startup Cost": 0.0,
+                                          "Total Cost": 11.5,
+                                          "Plan Rows": 150,
+                                          "Plan Width": 8,
+                                          "Actual Startup Time": 0.001,
+                                          "Actual Total Time": 0.02,
+                                          "Actual Rows": 518,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "supplier.s_suppkey",
+                                            "supplier.s_name",
+                                            "supplier.s_address",
+                                            "supplier.s_nationkey",
+                                            "supplier.s_phone",
+                                            "supplier.s_acctbal",
+                                            "supplier.s_comment"
+                                          ]
+                                        },
+                                        {
+                                          "Node Type": "Hash",
+                                          "Parent Relationship": "Inner",
+                                          "Parallel Aware": false,
+                                          "Async Capable": false,
+                                          "Startup Cost": 25.97,
+                                          "Total Cost": 25.97,
+                                          "Plan Rows": 1,
+                                          "Plan Width": 64,
+                                          "Actual Startup Time": 0.102,
+                                          "Actual Total Time": 0.102,
+                                          "Actual Rows": 28,
+                                          "Actual Loops": 1,
+                                          "Output": [
+                                            "part.p_partkey",
+                                            "lineitem.l_extendedprice",
+                                            "lineitem.l_discount",
+                                            "lineitem.l_quantity",
+                                            "lineitem.l_suppkey",
+                                            "lineitem.l_partkey",
+                                            "lineitem.l_orderkey"
+                                          ],
+                                          "Hash Buckets": 1024,
+                                          "Original Hash Buckets": 1024,
+                                          "Hash Batches": 1,
+                                          "Original Hash Batches": 1,
+                                          "Peak Memory Usage": 10,
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Hash Join",
+                                              "Parent Relationship": "Outer",
+                                              "Parallel Aware": false,
+                                              "Async Capable": false,
+                                              "Join Type": "Inner",
+                                              "Startup Cost": 13.21,
+                                              "Total Cost": 25.97,
+                                              "Plan Rows": 1,
+                                              "Plan Width": 64,
+                                              "Actual Startup Time": 0.053,
+                                              "Actual Total Time": 0.098,
+                                              "Actual Rows": 28,
+                                              "Actual Loops": 1,
+                                              "Output": [
+                                                "part.p_partkey",
+                                                "lineitem.l_extendedprice",
+                                                "lineitem.l_discount",
+                                                "lineitem.l_quantity",
+                                                "lineitem.l_suppkey",
+                                                "lineitem.l_partkey",
+                                                "lineitem.l_orderkey"
+                                              ],
+                                              "Inner Unique": false,
+                                              "Hash Cond": "(lineitem.l_partkey = part.p_partkey)",
+                                              "Plans": [
+                                                {
+                                                  "Node Type": "Seq Scan",
+                                                  "Parent Relationship": "Outer",
+                                                  "Parallel Aware": false,
+                                                  "Async Capable": false,
+                                                  "Relation Name": "lineitem",
+                                                  "Schema": "pg_temp",
+                                                  "Alias": "lineitem",
+                                                  "Startup Cost": 0.0,
+                                                  "Total Cost": 12.0,
+                                                  "Plan Rows": 200,
+                                                  "Plan Width": 60,
+                                                  "Actual Startup Time": 0.002,
+                                                  "Actual Total Time": 0.022,
+                                                  "Actual Rows": 572,
+                                                  "Actual Loops": 1,
+                                                  "Output": [
+                                                    "lineitem.l_orderkey",
+                                                    "lineitem.l_partkey",
+                                                    "lineitem.l_suppkey",
+                                                    "lineitem.l_linenumber",
+                                                    "lineitem.l_quantity",
+                                                    "lineitem.l_extendedprice",
+                                                    "lineitem.l_discount",
+                                                    "lineitem.l_tax",
+                                                    "lineitem.l_returnflag",
+                                                    "lineitem.l_linestatus",
+                                                    "lineitem.l_shipdate",
+                                                    "lineitem.l_commitdate",
+                                                    "lineitem.l_receiptdate",
+                                                    "lineitem.l_shipinstruct",
+                                                    "lineitem.l_shipmode",
+                                                    "lineitem.l_comment"
+                                                  ]
+                                                },
+                                                {
+                                                  "Node Type": "Hash",
+                                                  "Parent Relationship": "Inner",
+                                                  "Parallel Aware": false,
+                                                  "Async Capable": false,
+                                                  "Startup Cost": 13.2,
+                                                  "Total Cost": 13.2,
+                                                  "Plan Rows": 1,
+                                                  "Plan Width": 4,
+                                                  "Actual Startup Time": 0.05,
+                                                  "Actual Total Time": 0.05,
+                                                  "Actual Rows": 28,
+                                                  "Actual Loops": 1,
+                                                  "Output": [
+                                                    "part.p_partkey"
+                                                  ],
+                                                  "Hash Buckets": 1024,
+                                                  "Original Hash Buckets": 1024,
+                                                  "Hash Batches": 1,
+                                                  "Original Hash Batches": 1,
+                                                  "Peak Memory Usage": 9,
+                                                  "Plans": [
+                                                    {
+                                                      "Node Type": "Seq Scan",
+                                                      "Parent Relationship": "Outer",
+                                                      "Parallel Aware": false,
+                                                      "Async Capable": false,
+                                                      "Relation Name": "part",
+                                                      "Schema": "pg_temp",
+                                                      "Alias": "part",
+                                                      "Startup Cost": 0.0,
+                                                      "Total Cost": 13.2,
+                                                      "Plan Rows": 1,
+                                                      "Plan Width": 4,
+                                                      "Actual Startup Time": 0.002,
+                                                      "Actual Total Time": 0.048,
+                                                      "Actual Rows": 28,
+                                                      "Actual Loops": 1,
+                                                      "Output": [
+                                                        "part.p_partkey"
+                                                      ],
+                                                      "Filter": "((part.p_name)::text ~~ '%green%'::text)",
+                                                      "Rows Removed by Filter": 505
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.205,
+    "Triggers": [],
+    "Execution Time": 0.306
+  }
+]

--- a/standalone-app/examples/postgres/window-analyze.plan.json
+++ b/standalone-app/examples/postgres/window-analyze.plan.json
@@ -1,1 +1,131 @@
-[{"Plan": {"Node Type": "WindowAgg", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 30.81, "Total Cost": 34.29, "Plan Rows": 200, "Plan Width": 72, "Actual Startup Time": 0.335, "Actual Total Time": 0.452, "Actual Rows": 572, "Actual Loops": 1, "Output": ["l_orderkey", "sum(l_quantity) OVER (?)", "(avg(l_extendedprice) OVER (?))", "l_shipdate"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 30.79, "Total Cost": 31.29, "Plan Rows": 200, "Plan Width": 72, "Actual Startup Time": 0.325, "Actual Total Time": 0.342, "Actual Rows": 572, "Actual Loops": 1, "Output": ["l_orderkey", "l_shipdate", "l_quantity", "l_extendedprice", "(avg(l_extendedprice) OVER (?))"], "Sort Key": ["lineitem.l_orderkey"], "Sort Method": "quicksort", "Sort Space Used": 51, "Sort Space Type": "Memory", "Plans": [{"Node Type": "WindowAgg", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 19.71, "Total Cost": 23.14, "Plan Rows": 200, "Plan Width": 72, "Actual Startup Time": 0.086, "Actual Total Time": 0.268, "Actual Rows": 572, "Actual Loops": 1, "Output": ["l_orderkey", "l_shipdate", "l_quantity", "l_extendedprice", "avg(l_extendedprice) OVER (?)"], "Plans": [{"Node Type": "Sort", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Startup Cost": 19.64, "Total Cost": 20.14, "Plan Rows": 200, "Plan Width": 40, "Actual Startup Time": 0.082, "Actual Total Time": 0.095, "Actual Rows": 572, "Actual Loops": 1, "Output": ["l_orderkey", "l_shipdate", "l_quantity", "l_extendedprice"], "Sort Key": ["lineitem.l_shipdate"], "Sort Method": "quicksort", "Sort Space Used": 47, "Sort Space Type": "Memory", "Plans": [{"Node Type": "Seq Scan", "Parent Relationship": "Outer", "Parallel Aware": false, "Async Capable": false, "Relation Name": "lineitem", "Schema": "pg_temp", "Alias": "lineitem", "Startup Cost": 0.0, "Total Cost": 12.0, "Plan Rows": 200, "Plan Width": 40, "Actual Startup Time": 0.003, "Actual Total Time": 0.035, "Actual Rows": 572, "Actual Loops": 1, "Output": ["l_orderkey", "l_shipdate", "l_quantity", "l_extendedprice"]}]}]}]}]}, "Planning Time": 0.026, "Triggers": [], "Execution Time": 0.471}]
+[
+  {
+    "Plan": {
+      "Node Type": "WindowAgg",
+      "Parallel Aware": false,
+      "Async Capable": false,
+      "Startup Cost": 30.81,
+      "Total Cost": 34.29,
+      "Plan Rows": 200,
+      "Plan Width": 72,
+      "Actual Startup Time": 0.453,
+      "Actual Total Time": 0.628,
+      "Actual Rows": 572,
+      "Actual Loops": 1,
+      "Output": [
+        "l_orderkey",
+        "sum(l_quantity) OVER (?)",
+        "(avg(l_extendedprice) OVER (?))",
+        "l_shipdate"
+      ],
+      "Plans": [
+        {
+          "Node Type": "Sort",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Async Capable": false,
+          "Startup Cost": 30.79,
+          "Total Cost": 31.29,
+          "Plan Rows": 200,
+          "Plan Width": 72,
+          "Actual Startup Time": 0.448,
+          "Actual Total Time": 0.464,
+          "Actual Rows": 572,
+          "Actual Loops": 1,
+          "Output": [
+            "l_orderkey",
+            "l_shipdate",
+            "l_quantity",
+            "l_extendedprice",
+            "(avg(l_extendedprice) OVER (?))"
+          ],
+          "Sort Key": [
+            "lineitem.l_orderkey"
+          ],
+          "Sort Method": "quicksort",
+          "Sort Space Used": 51,
+          "Sort Space Type": "Memory",
+          "Plans": [
+            {
+              "Node Type": "WindowAgg",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 19.71,
+              "Total Cost": 23.14,
+              "Plan Rows": 200,
+              "Plan Width": 72,
+              "Actual Startup Time": 0.12,
+              "Actual Total Time": 0.371,
+              "Actual Rows": 572,
+              "Actual Loops": 1,
+              "Output": [
+                "l_orderkey",
+                "l_shipdate",
+                "l_quantity",
+                "l_extendedprice",
+                "avg(l_extendedprice) OVER (?)"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "Sort",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Async Capable": false,
+                  "Startup Cost": 19.64,
+                  "Total Cost": 20.14,
+                  "Plan Rows": 200,
+                  "Plan Width": 40,
+                  "Actual Startup Time": 0.115,
+                  "Actual Total Time": 0.131,
+                  "Actual Rows": 572,
+                  "Actual Loops": 1,
+                  "Output": [
+                    "l_orderkey",
+                    "l_shipdate",
+                    "l_quantity",
+                    "l_extendedprice"
+                  ],
+                  "Sort Key": [
+                    "lineitem.l_shipdate"
+                  ],
+                  "Sort Method": "quicksort",
+                  "Sort Space Used": 47,
+                  "Sort Space Type": "Memory",
+                  "Plans": [
+                    {
+                      "Node Type": "Seq Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Async Capable": false,
+                      "Relation Name": "lineitem",
+                      "Schema": "pg_temp",
+                      "Alias": "lineitem",
+                      "Startup Cost": 0.0,
+                      "Total Cost": 12.0,
+                      "Plan Rows": 200,
+                      "Plan Width": 40,
+                      "Actual Startup Time": 0.002,
+                      "Actual Total Time": 0.049,
+                      "Actual Rows": 572,
+                      "Actual Loops": 1,
+                      "Output": [
+                        "l_orderkey",
+                        "l_shipdate",
+                        "l_quantity",
+                        "l_extendedprice"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.015,
+    "Triggers": [],
+    "Execution Time": 0.653
+  }
+]


### PR DESCRIPTION
Postgres' EXPLAIN JSON was written as a single compact line, making git diffs rather unreadable and making it impossible to tell a real plan change from a re-timed run. DuckDB and Hyper already emit multi-line JSON; Postgres now matches, via `json.dumps(..., indent=2)`.