### PR TITLE
Tighten pipeline colour-bar spacing

### DIFF
--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -23,7 +23,8 @@
     font-size: .7em;
     width: 1em;
     height: 1em;
-    bottom: -.8em;
+    /* Sit below the colour bar instead of overlapping it. */
+    bottom: -1.15em;
     line-height: 1em;
     text-align: center;
     border-radius: 0.5em;
@@ -70,8 +71,6 @@
 }
 .qg-color-bar-below {
     margin-top: 4px;
-    /* Keep the bar above the subtree +/- handle at the bottom of the node. */
-    margin-bottom: 1em;
 }
 .qg-color-bar-seg {
     flex: 1 1 0;

--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -71,10 +71,6 @@
 .qg-color-bar-below {
     margin-top: 4px;
 }
-.query-graph .react-flow__node-querynode:hover .qg-color-bar-below,
-.qg-graph-node.qg-expanded .qg-color-bar-below {
-    margin-bottom: 0.8em;
-}
 .qg-color-bar-seg {
     flex: 1 1 0;
     border-radius: 2px;

--- a/query-graphs/src/ui/QueryNode.css
+++ b/query-graphs/src/ui/QueryNode.css
@@ -23,8 +23,7 @@
     font-size: .7em;
     width: 1em;
     height: 1em;
-    /* Sit below the colour bar instead of overlapping it. */
-    bottom: -1.15em;
+    bottom: -.8em;
     line-height: 1em;
     text-align: center;
     border-radius: 0.5em;
@@ -71,6 +70,10 @@
 }
 .qg-color-bar-below {
     margin-top: 4px;
+}
+.query-graph .react-flow__node-querynode:hover .qg-color-bar-below,
+.qg-graph-node.qg-expanded .qg-color-bar-below {
+    margin-bottom: 0.8em;
 }
 .qg-color-bar-seg {
     flex: 1 1 0;

--- a/query-graphs/src/ui/QueryNode.tsx
+++ b/query-graphs/src/ui/QueryNode.tsx
@@ -99,13 +99,14 @@ function QueryNode({data, id}: NodeProps<QueryGraphNode>) {
                     <div className="qg-graph-node-label" style={{background: data.nodeColor}}>
                         {data.name}
                     </div>
+                    {expanded ? null : colorBar(data.barsBelow, "below")}
                 </div>
                 <div className="qg-graph-node-body-wrapper nowheel">
                     <div ref={bodyRef} className="qg-graph-node-body">
                         {children}
                     </div>
                 </div>
-                {colorBar(data.barsBelow, "below")}
+                {expanded ? colorBar(data.barsBelow, "below") : null}
             </div>
             <Handle type="source" position={Position.Bottom} className={handleClassName} onClick={onSubtreeHandleClick}>
                 {hasSubtree ? (subtreeExpanded ? "-" : "+") : ""}

--- a/query-graphs/src/ui/QueryNode.tsx
+++ b/query-graphs/src/ui/QueryNode.tsx
@@ -99,14 +99,13 @@ function QueryNode({data, id}: NodeProps<QueryGraphNode>) {
                     <div className="qg-graph-node-label" style={{background: data.nodeColor}}>
                         {data.name}
                     </div>
-                    {expanded ? null : colorBar(data.barsBelow, "below")}
                 </div>
                 <div className="qg-graph-node-body-wrapper nowheel">
                     <div ref={bodyRef} className="qg-graph-node-body">
                         {children}
                     </div>
                 </div>
-                {expanded ? colorBar(data.barsBelow, "below") : null}
+                {colorBar(data.barsBelow, "below")}
             </div>
             <Handle type="source" position={Position.Bottom} className={handleClassName} onClick={onSubtreeHandleClick}>
                 {hasSubtree ? (subtreeExpanded ? "-" : "+") : ""}


### PR DESCRIPTION
The 1em margin under every lower pipeline colour bar kept the subtree handle clear, but it also left a large gap between operators and their outgoing edges. Remove that margin so edges sit close to the bars.

The lower colour bar already follows the collapsible property body in the DOM. The body has zero height while properties are hidden and expands in place when they are shown, so removing the margin is sufficient. Hovering only reveals the absolutely positioned subtree handle and does not resize the node.

Verified with the TypeScript build, the full ESLint check, and the forkshare, materialized, unionall, and magicunnesting pipeline plans on the development server.